### PR TITLE
OpenACC Model

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -155,7 +155,7 @@ endif ()
 
 # setup some defaults flags for everything
 set(DEFAULT_DEBUG_CXX_FLAGS -Wall -O2)
-set(DEFAULT_RELEASE_CXX_FLAGS -Wall -O3 -march=native)
+set(DEFAULT_RELEASE_CXX_FLAGS -Wall -O3)
 
 macro(hint_flag FLAG DESCRIPTION)
     if (NOT DEFINED ${FLAG})
@@ -298,6 +298,7 @@ register_model(cuda USE_CUDA ${MODEL_SRC})
 register_model(hip USE_HIP ${MODEL_SRC})
 register_model(std-indices USE_STD ${MODEL_SRC})
 register_model(kokkos USE_KOKKOS ${MODEL_SRC})
+register_model(acc ACC ${MODEL_SRC})
 register_model(sycl-acc USE_SYCL_ACC ${MODEL_SRC})
 register_model(sycl-usm USE_SYCL_USM ${MODEL_SRC})
 

--- a/src/acc/PdV.cpp
+++ b/src/acc/PdV.cpp
@@ -1,0 +1,184 @@
+/*
+ Crown Copyright 2012 AWE.
+
+ This file is part of CloverLeaf.
+
+ CloverLeaf is free software: you can redistribute it and/or modify it under
+ the terms of the GNU General Public License as published by the
+ Free Software Foundation, either version 3 of the License, or (at your option)
+ any later version.
+
+ CloverLeaf is distributed in the hope that it will be useful, but
+ WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ details.
+
+ You should have received a copy of the GNU General Public License along with
+ CloverLeaf. If not, see http://www.gnu.org/licenses/.
+ */
+
+#include "PdV.h"
+#include "comms.h"
+#include "ideal_gas.h"
+#include "report.h"
+#include "revert.h"
+#include "timer.h"
+#include "update_halo.h"
+#include <cmath>
+
+//  @brief Fortran PdV kernel.
+//  @author Wayne Gaudin
+//  @details Calculates the change in energy and density in a cell using the
+//  change on cell volume due to the velocity gradients in a cell. The time
+//  level of the velocity data depends on whether it is invoked as the
+//  predictor or corrector.
+void PdV_kernel(bool use_target, bool predict, int x_min, int x_max, int y_min, int y_max, double dt, field_type &field) {
+
+  const int base_stride = field.base_stride;
+  const int vels_wk_stride = field.vels_wk_stride;
+  const int flux_x_stride = field.flux_x_stride;
+  const int flux_y_stride = field.flux_y_stride;
+
+  // DO k=y_min,y_max
+  //   DO j=x_min,x_max
+
+  if (predict) {
+
+    double *xarea = field.xarea.data;
+
+    double *yarea = field.yarea.data;
+    double *volume = field.volume.data;
+    double *density0 = field.density0.data;
+    double *density1 = field.density1.data;
+    double *energy0 = field.energy0.data;
+    double *energy1 = field.energy1.data;
+    double *pressure = field.pressure.data;
+    double *viscosity = field.viscosity.data;
+    double *xvel0 = field.xvel0.data;
+    double *yvel0 = field.yvel0.data;
+
+#pragma omp target teams distribute parallel for simd collapse(2) clover_use_target(use_target)
+    for (int j = (y_min + 1); j < (y_max + 2); j++) {
+      for (int i = (x_min + 1); i < (x_max + 2); i++) {
+        double left_flux = (xarea[i + j * flux_x_stride] * (xvel0[i + j * vels_wk_stride] + xvel0[(i + 0) + (j + 1) * vels_wk_stride] +
+                                                            xvel0[i + j * vels_wk_stride] + xvel0[(i + 0) + (j + 1) * vels_wk_stride])) *
+                           0.25 * dt * 0.5;
+        double right_flux = (xarea[(i + 1) + (j + 0) * flux_x_stride] *
+                             (xvel0[(i + 1) + (j + 0) * vels_wk_stride] + xvel0[(i + 1) + (j + 1) * vels_wk_stride] +
+                              xvel0[(i + 1) + (j + 0) * vels_wk_stride] + xvel0[(i + 1) + (j + 1) * vels_wk_stride])) *
+                            0.25 * dt * 0.5;
+        double bottom_flux = (yarea[i + j * flux_y_stride] * (yvel0[i + j * vels_wk_stride] + yvel0[(i + 1) + (j + 0) * vels_wk_stride] +
+                                                              yvel0[i + j * vels_wk_stride] + yvel0[(i + 1) + (j + 0) * vels_wk_stride])) *
+                             0.25 * dt * 0.5;
+        double top_flux = (yarea[(i + 0) + (j + 1) * flux_y_stride] *
+                           (yvel0[(i + 0) + (j + 1) * vels_wk_stride] + yvel0[(i + 1) + (j + 1) * vels_wk_stride] +
+                            yvel0[(i + 0) + (j + 1) * vels_wk_stride] + yvel0[(i + 1) + (j + 1) * vels_wk_stride])) *
+                          0.25 * dt * 0.5;
+        double total_flux = right_flux - left_flux + top_flux - bottom_flux;
+        double volume_change_s = volume[i + j * base_stride] / (volume[i + j * base_stride] + total_flux);
+        double recip_volume = 1.0 / volume[i + j * base_stride];
+        double energy_change = (pressure[i + j * base_stride] / density0[i + j * base_stride] +
+                                viscosity[i + j * base_stride] / density0[i + j * base_stride]) *
+                               total_flux * recip_volume;
+        energy1[i + j * base_stride] = energy0[i + j * base_stride] - energy_change;
+        density1[i + j * base_stride] = density0[i + j * base_stride] * volume_change_s;
+      }
+    }
+
+  } else {
+
+    double *xarea = field.xarea.data;
+    double *yarea = field.yarea.data;
+    double *volume = field.volume.data;
+    double *density0 = field.density0.data;
+    double *density1 = field.density1.data;
+    double *energy0 = field.energy0.data;
+    double *energy1 = field.energy1.data;
+    double *pressure = field.pressure.data;
+    double *viscosity = field.viscosity.data;
+    double *xvel0 = field.xvel0.data;
+    double *xvel1 = field.xvel1.data;
+    double *yvel0 = field.yvel0.data;
+    double *yvel1 = field.yvel1.data;
+
+#pragma omp target teams distribute parallel for simd collapse(2) clover_use_target(use_target)
+    for (int j = (y_min + 1); j < (y_max + 2); j++) {
+      for (int i = (x_min + 1); i < (x_max + 2); i++) {
+        double left_flux = (xarea[i + j * flux_x_stride] * (xvel0[i + j * vels_wk_stride] + xvel0[(i + 0) + (j + 1) * vels_wk_stride] +
+                                                            xvel1[i + j * vels_wk_stride] + xvel1[(i + 0) + (j + 1) * vels_wk_stride])) *
+                           0.25 * dt;
+        double right_flux = (xarea[(i + 1) + (j + 0) * flux_x_stride] *
+                             (xvel0[(i + 1) + (j + 0) * vels_wk_stride] + xvel0[(i + 1) + (j + 1) * vels_wk_stride] +
+                              xvel1[(i + 1) + (j + 0) * vels_wk_stride] + xvel1[(i + 1) + (j + 1) * vels_wk_stride])) *
+                            0.25 * dt;
+        double bottom_flux = (yarea[i + j * flux_y_stride] * (yvel0[i + j * vels_wk_stride] + yvel0[(i + 1) + (j + 0) * vels_wk_stride] +
+                                                              yvel1[i + j * vels_wk_stride] + yvel1[(i + 1) + (j + 0) * vels_wk_stride])) *
+                             0.25 * dt;
+        double top_flux = (yarea[(i + 0) + (j + 1) * flux_y_stride] *
+                           (yvel0[(i + 0) + (j + 1) * vels_wk_stride] + yvel0[(i + 1) + (j + 1) * vels_wk_stride] +
+                            yvel1[(i + 0) + (j + 1) * vels_wk_stride] + yvel1[(i + 1) + (j + 1) * vels_wk_stride])) *
+                          0.25 * dt;
+        double total_flux = right_flux - left_flux + top_flux - bottom_flux;
+        double volume_change_s = volume[i + j * base_stride] / (volume[i + j * base_stride] + total_flux);
+        double recip_volume = 1.0 / volume[i + j * base_stride];
+        double energy_change = (pressure[i + j * base_stride] / density0[i + j * base_stride] +
+                                viscosity[i + j * base_stride] / density0[i + j * base_stride]) *
+                               total_flux * recip_volume;
+        energy1[i + j * base_stride] = energy0[i + j * base_stride] - energy_change;
+        density1[i + j * base_stride] = density0[i + j * base_stride] * volume_change_s;
+      }
+    }
+  }
+}
+
+//  @brief Driver for the PdV update.
+//  @author Wayne Gaudin
+//  @details Invokes the user specified kernel for the PdV update.
+void PdV(global_variables &globals, bool predict) {
+
+  double kernel_time = 0;
+  if (globals.profiler_on) kernel_time = timer();
+
+  globals.error_condition = 0;
+
+#if SYNC_BUFFERS
+  globals.hostToDevice();
+#endif
+
+  for (int tile = 0; tile < globals.config.tiles_per_chunk; ++tile) {
+    tile_type &t = globals.chunk.tiles[tile];
+    PdV_kernel(globals.context.use_target, predict, t.info.t_xmin, t.info.t_xmax, t.info.t_ymin, t.info.t_ymax, globals.dt, t.field);
+  }
+
+#if SYNC_BUFFERS
+  globals.deviceToHost();
+#endif
+
+  clover_check_error(globals.error_condition);
+  if (globals.profiler_on) globals.profiler.PdV += timer() - kernel_time;
+
+  if (globals.error_condition == 1) {
+    report_error((char *)"PdV", (char *)"error in PdV");
+  }
+
+  if (predict) {
+    if (globals.profiler_on) kernel_time = timer();
+    for (int tile = 0; tile < globals.config.tiles_per_chunk; ++tile) {
+      ideal_gas(globals, tile, true);
+    }
+
+    if (globals.profiler_on) globals.profiler.ideal_gas += timer() - kernel_time;
+
+    int fields[NUM_FIELDS];
+    for (int &field : fields)
+      field = 0;
+    fields[field_pressure] = 1;
+    update_halo(globals, fields, 1);
+  }
+
+  if (predict) {
+    if (globals.profiler_on) kernel_time = timer();
+    revert(globals);
+    if (globals.profiler_on) globals.profiler.revert += timer() - kernel_time;
+  }
+}

--- a/src/acc/PdV.cpp
+++ b/src/acc/PdV.cpp
@@ -57,7 +57,7 @@ void PdV_kernel(bool use_target, bool predict, int x_min, int x_max, int y_min, 
     double *xvel0 = field.xvel0.data;
     double *yvel0 = field.yvel0.data;
 
-#pragma omp target teams distribute parallel for simd collapse(2) clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector default(present) collapse(2) clover_use_target(use_target)
     for (int j = (y_min + 1); j < (y_max + 2); j++) {
       for (int i = (x_min + 1); i < (x_max + 2); i++) {
         double left_flux = (xarea[i + j * flux_x_stride] * (xvel0[i + j * vels_wk_stride] + xvel0[(i + 0) + (j + 1) * vels_wk_stride] +
@@ -101,7 +101,7 @@ void PdV_kernel(bool use_target, bool predict, int x_min, int x_max, int y_min, 
     double *yvel0 = field.yvel0.data;
     double *yvel1 = field.yvel1.data;
 
-#pragma omp target teams distribute parallel for simd collapse(2) clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector default(present) collapse(2) clover_use_target(use_target)
     for (int j = (y_min + 1); j < (y_max + 2); j++) {
       for (int i = (x_min + 1); i < (x_max + 2); i++) {
         double left_flux = (xarea[i + j * flux_x_stride] * (xvel0[i + j * vels_wk_stride] + xvel0[(i + 0) + (j + 1) * vels_wk_stride] +

--- a/src/acc/PdV.cpp
+++ b/src/acc/PdV.cpp
@@ -57,7 +57,12 @@ void PdV_kernel(bool use_target, bool predict, int x_min, int x_max, int y_min, 
     double *xvel0 = field.xvel0.data;
     double *yvel0 = field.yvel0.data;
 
-#pragma acc parallel loop gang worker vector default(present) collapse(2) clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector collapse(2) clover_use_target(use_target)         \
+    present(xarea[ : field.xarea.N()], yarea[ : field.yarea.N()], volume[ : field.volume.N()], \
+            density0[ : field.density0.N()], density1[ : field.density1.N()],                  \
+            energy0[ : field.energy0.N()], energy1[ : field.energy1.N()],                      \
+            pressure[ : field.pressure.N()], viscosity[ : field.viscosity.N()],                \
+            xvel0[ : field.xvel0.N()], yvel0[: field.yvel0.N()])
     for (int j = (y_min + 1); j < (y_max + 2); j++) {
       for (int i = (x_min + 1); i < (x_max + 2); i++) {
         double left_flux = (xarea[i + j * flux_x_stride] * (xvel0[i + j * vels_wk_stride] + xvel0[(i + 0) + (j + 1) * vels_wk_stride] +
@@ -101,7 +106,13 @@ void PdV_kernel(bool use_target, bool predict, int x_min, int x_max, int y_min, 
     double *yvel0 = field.yvel0.data;
     double *yvel1 = field.yvel1.data;
 
-#pragma acc parallel loop gang worker vector default(present) collapse(2) clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector collapse(2) clover_use_target(use_target)         \
+    present(xarea[ : field.xarea.N()], yarea[ : field.yarea.N()], volume[ : field.volume.N()], \
+            density0[ : field.density0.N()], density1[ : field.density1.N()],                  \
+            energy0[ : field.energy0.N()], energy1[ : field.energy1.N()],                      \
+            pressure[ : field.pressure.N()], viscosity[ : field.viscosity.N()],                \
+            xvel0[ : field.xvel0.N()], xvel1[ : field.xvel1.N()],                              \
+            yvel0[: field.yvel0.N()], yvel1[ : field.yvel1.N()])
     for (int j = (y_min + 1); j < (y_max + 2); j++) {
       for (int i = (x_min + 1); i < (x_max + 2); i++) {
         double left_flux = (xarea[i + j * flux_x_stride] * (xvel0[i + j * vels_wk_stride] + xvel0[(i + 0) + (j + 1) * vels_wk_stride] +

--- a/src/acc/accelerate.cpp
+++ b/src/acc/accelerate.cpp
@@ -1,0 +1,109 @@
+/*
+ Crown Copyright 2012 AWE.
+
+ This file is part of CloverLeaf.
+
+ CloverLeaf is free software: you can redistribute it and/or modify it under
+ the terms of the GNU General Public License as published by the
+ Free Software Foundation, either version 3 of the License, or (at your option)
+ any later version.
+
+ CloverLeaf is distributed in the hope that it will be useful, but
+ WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ details.
+
+ You should have received a copy of the GNU General Public License along with
+ CloverLeaf. If not, see http://www.gnu.org/licenses/.
+ */
+
+#include "accelerate.h"
+#include "timer.h"
+
+// @brief Fortran acceleration kernel
+// @author Wayne Gaudin
+// @details The pressure and viscosity gradients are used to update the
+// velocity field.
+void accelerate_kernel(bool use_target, int x_min, int x_max, int y_min, int y_max, double dt, field_type &field) {
+
+  double halfdt = 0.5 * dt;
+
+  // DO k=y_min,y_max+1
+  //   DO j=x_min,x_max+1
+  //	Kokkos::MDRangePolicy <Kokkos::Rank<2>> policy({x_min + 1, y_min + 1},
+  //	                                               {x_max + 1 + 2, y_max + 1 + 2});
+
+  // for(int j = )
+
+  const int xarea_sizex = field.flux_x_stride;
+  const int yarea_sizex = field.flux_y_stride;
+  const int base_stride = field.base_stride;
+  const int vels_wk_stride = field.vels_wk_stride;
+
+  double *xarea = field.xarea.data;
+  double *yarea = field.yarea.data;
+  double *volume = field.volume.data;
+  double *density0 = field.density0.data;
+  double *pressure = field.pressure.data;
+  double *viscosity = field.viscosity.data;
+  double *xvel0 = field.xvel0.data;
+  double *yvel0 = field.yvel0.data;
+  double *xvel1 = field.xvel1.data;
+  double *yvel1 = field.yvel1.data;
+
+#pragma omp target teams distribute parallel for simd collapse(2) clover_use_target(use_target)
+  for (int j = (y_min + 1); j < (y_max + 1 + 2); j++) {
+    for (int i = (x_min + 1); i < (x_max + 1 + 2); i++) {
+      double stepbymass_s = halfdt / ((density0[(i - 1) + (j - 1) * base_stride] * volume[(i - 1) + (j - 1) * base_stride] +
+                                       density0[(i - 1) + (j + 0) * base_stride] * volume[(i - 1) + (j + 0) * base_stride] +
+                                       density0[i + j * base_stride] * volume[i + j * base_stride] +
+                                       density0[(i + 0) + (j - 1) * base_stride] * volume[(i + 0) + (j - 1) * base_stride]) *
+                                      0.25);
+      xvel1[i + j * vels_wk_stride] =
+          xvel0[i + j * vels_wk_stride] -
+          stepbymass_s * (xarea[i + j * xarea_sizex] * (pressure[i + j * base_stride] - pressure[(i - 1) + (j + 0) * base_stride]) +
+                          xarea[(i + 0) + (j - 1) * xarea_sizex] *
+                              (pressure[(i + 0) + (j - 1) * base_stride] - pressure[(i - 1) + (j - 1) * base_stride]));
+      yvel1[i + j * vels_wk_stride] =
+          yvel0[i + j * vels_wk_stride] -
+          stepbymass_s * (yarea[i + j * yarea_sizex] * (pressure[i + j * base_stride] - pressure[(i + 0) + (j - 1) * base_stride]) +
+                          yarea[(i - 1) + (j + 0) * yarea_sizex] *
+                              (pressure[(i - 1) + (j + 0) * base_stride] - pressure[(i - 1) + (j - 1) * base_stride]));
+      xvel1[i + j * vels_wk_stride] =
+          xvel1[i + j * vels_wk_stride] -
+          stepbymass_s * (xarea[i + j * xarea_sizex] * (viscosity[i + j * base_stride] - viscosity[(i - 1) + (j + 0) * base_stride]) +
+                          xarea[(i + 0) + (j - 1) * xarea_sizex] *
+                              (viscosity[(i + 0) + (j - 1) * base_stride] - viscosity[(i - 1) + (j - 1) * base_stride]));
+      yvel1[i + j * vels_wk_stride] =
+          yvel1[i + j * vels_wk_stride] -
+          stepbymass_s * (yarea[i + j * yarea_sizex] * (viscosity[i + j * base_stride] - viscosity[(i + 0) + (j - 1) * base_stride]) +
+                          yarea[(i - 1) + (j + 0) * yarea_sizex] *
+                              (viscosity[(i - 1) + (j + 0) * base_stride] - viscosity[(i - 1) + (j - 1) * base_stride]));
+    }
+  }
+}
+
+//  @brief Driver for the acceleration kernels
+//  @author Wayne Gaudin
+//  @details Calls user requested kernel
+void accelerate(global_variables &globals) {
+
+  double kernel_time = 0;
+  if (globals.profiler_on) kernel_time = timer();
+
+#if SYNC_BUFFERS
+  globals.hostToDevice();
+#endif
+
+  for (int tile = 0; tile < globals.config.tiles_per_chunk; ++tile) {
+    tile_type &t = globals.chunk.tiles[tile];
+
+    accelerate_kernel(globals.context.use_target, t.info.t_xmin, t.info.t_xmax, t.info.t_ymin, t.info.t_ymax, globals.dt, t.field);
+  }
+
+#if SYNC_BUFFERS
+  globals.deviceToHost();
+#endif
+
+  if (globals.profiler_on) globals.profiler.acceleration += timer() - kernel_time;
+}

--- a/src/acc/accelerate.cpp
+++ b/src/acc/accelerate.cpp
@@ -51,7 +51,7 @@ void accelerate_kernel(bool use_target, int x_min, int x_max, int y_min, int y_m
   double *xvel1 = field.xvel1.data;
   double *yvel1 = field.yvel1.data;
 
-#pragma omp target teams distribute parallel for simd collapse(2) clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector default(present) collapse(2) clover_use_target(use_target)
   for (int j = (y_min + 1); j < (y_max + 1 + 2); j++) {
     for (int i = (x_min + 1); i < (x_max + 1 + 2); i++) {
       double stepbymass_s = halfdt / ((density0[(i - 1) + (j - 1) * base_stride] * volume[(i - 1) + (j - 1) * base_stride] +

--- a/src/acc/accelerate.cpp
+++ b/src/acc/accelerate.cpp
@@ -51,7 +51,12 @@ void accelerate_kernel(bool use_target, int x_min, int x_max, int y_min, int y_m
   double *xvel1 = field.xvel1.data;
   double *yvel1 = field.yvel1.data;
 
-#pragma acc parallel loop gang worker vector default(present) collapse(2) clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector collapse(2) clover_use_target(use_target)        \
+    present(xarea[ : field.xarea.N()], yarea[ : field.yarea.N()],                             \
+            volume[ : field.volume.N()], density0[ : field.density0.N()],                     \
+            pressure[ : field.pressure.N()], viscosity[ : field.viscosity.N()],               \
+            xvel0[ : field.xvel0.N()], xvel1[ : field.xvel1.N()],                             \
+            yvel0[: field.yvel0.N()], yvel1[ : field.yvel1.N()])
   for (int j = (y_min + 1); j < (y_max + 1 + 2); j++) {
     for (int i = (x_min + 1); i < (x_max + 1 + 2); i++) {
       double stepbymass_s = halfdt / ((density0[(i - 1) + (j - 1) * base_stride] * volume[(i - 1) + (j - 1) * base_stride] +

--- a/src/acc/advec_cell.cpp
+++ b/src/acc/advec_cell.cpp
@@ -1,0 +1,289 @@
+/*
+ Crown Copyright 2012 AWE.
+
+ This file is part of CloverLeaf.
+
+ CloverLeaf is free software: you can redistribute it and/or modify it under
+ the terms of the GNU General Public License as published by the
+ Free Software Foundation, either version 3 of the License, or (at your option)
+ any later version.
+
+ CloverLeaf is distributed in the hope that it will be useful, but
+ WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ details.
+
+ You should have received a copy of the GNU General Public License along with
+ CloverLeaf. If not, see http://www.gnu.org/licenses/.
+ */
+
+#include "advec_cell.h"
+#include <cmath>
+
+#define MIN(x, y) (((x) < (y)) ? (x) : (y))
+
+//  @brief Fortran cell advection kernel.
+//  @author Wayne Gaudin
+//  @details Performs a second order advective remap using van-Leer limiting
+//  with directional splitting.
+void advec_cell_kernel(bool use_target, int x_min, int x_max, int y_min, int y_max, int dir, int sweep_number, field_type &field) {
+
+  const double one_by_six = 1.0 / 6.0;
+
+  const size_t base_stride = field.base_stride;
+  const size_t vels_wk_stride = field.vels_wk_stride;
+  const size_t flux_x_stride = field.flux_x_stride;
+  const size_t flux_y_stride = field.flux_y_stride;
+
+  if (dir == g_xdir) {
+
+    // DO k=y_min-2,y_max+2
+    //   DO j=x_min-2,x_max+2
+
+    if (sweep_number == 1) {
+
+      double *volume = field.volume.data;
+      double *vol_flux_x = field.vol_flux_x.data;
+      double *vol_flux_y = field.vol_flux_y.data;
+      double *pre_vol = field.work_array1.data;
+      double *post_vol = field.work_array2.data;
+
+#pragma omp target teams distribute parallel for simd collapse(2) clover_use_target(use_target)
+      for (int j = (y_min - 2 + 1); j < (y_max + 2 + 2); j++) {
+        for (int i = (x_min - 2 + 1); i < (x_max + 2 + 2); i++) {
+          pre_vol[i + j * vels_wk_stride] =
+              volume[i + j * base_stride] + (vol_flux_x[(i + 1) + (j + 0) * flux_x_stride] - vol_flux_x[i + j * flux_x_stride] +
+                                             vol_flux_y[(i + 0) + (j + 1) * flux_y_stride] - vol_flux_y[i + j * flux_y_stride]);
+          post_vol[i + j * vels_wk_stride] =
+              pre_vol[i + j * vels_wk_stride] - (vol_flux_x[(i + 1) + (j + 0) * flux_x_stride] - vol_flux_x[i + j * flux_x_stride]);
+        }
+      }
+
+    } else {
+
+      double *volume = field.volume.data;
+      double *vol_flux_x = field.vol_flux_x.data;
+      double *pre_vol = field.work_array1.data;
+      double *post_vol = field.work_array2.data;
+
+#pragma omp target teams distribute parallel for simd collapse(2) clover_use_target(use_target)
+      for (int j = (y_min - 2 + 1); j < (y_max + 2 + 2); j++) {
+        for (int i = (x_min - 2 + 1); i < (x_max + 2 + 2); i++) {
+          pre_vol[i + j * vels_wk_stride] =
+              volume[i + j * base_stride] + vol_flux_x[(i + 1) + (j + 0) * flux_x_stride] - vol_flux_x[i + j * flux_x_stride];
+          post_vol[i + j * vels_wk_stride] = volume[i + j * base_stride];
+        }
+      }
+    }
+
+    // DO k=y_min,y_max
+    //   DO j=x_min,x_max+2
+    double *vertexdx = field.vertexdx.data;
+    double *density1 = field.density1.data;
+    double *energy1 = field.energy1.data;
+    double *mass_flux_x = field.mass_flux_x.data;
+    double *vol_flux_x = field.vol_flux_x.data;
+    double *pre_vol = field.work_array1.data;
+    double *ener_flux = field.work_array7.data;
+
+#pragma omp target teams distribute parallel for simd collapse(2) clover_use_target(use_target)
+    for (int j = (y_min + 1); j < (y_max + 2); j++) {
+      for (int i = (x_min + 1); i < (x_max + 2 + 2); i++)
+        ({
+          int upwind, donor, downwind, dif;
+          double sigmat, sigma3, sigma4, sigmav, sigmam, diffuw, diffdw, limiter, wind;
+          if (vol_flux_x[i + j * flux_x_stride] > 0.0) {
+            upwind = i - 2;
+            donor = i - 1;
+            downwind = i;
+            dif = donor;
+          } else {
+            upwind = MIN(i + 1, x_max + 2);
+            donor = i;
+            downwind = i - 1;
+            dif = upwind;
+          }
+          sigmat = fabs(vol_flux_x[i + j * flux_x_stride]) / pre_vol[donor + j * vels_wk_stride];
+          sigma3 = (1.0 + sigmat) * (vertexdx[i] / vertexdx[dif]);
+          sigma4 = 2.0 - sigmat;
+          //					sigma = sigmat;
+          sigmav = sigmat;
+          diffuw = density1[donor + j * base_stride] - density1[upwind + j * base_stride];
+          diffdw = density1[downwind + j * base_stride] - density1[donor + j * base_stride];
+          wind = 1.0;
+          if (diffdw <= 0.0) wind = -1.0;
+          if (diffuw * diffdw > 0.0) {
+            limiter = (1.0 - sigmav) * wind *
+                      fmin(fmin(fabs(diffuw), fabs(diffdw)), one_by_six * (sigma3 * fabs(diffuw) + sigma4 * fabs(diffdw)));
+          } else {
+            limiter = 0.0;
+          }
+          mass_flux_x[i + j * flux_x_stride] = vol_flux_x[i + j * flux_x_stride] * (density1[donor + j * base_stride] + limiter);
+          sigmam = fabs(mass_flux_x[i + j * flux_x_stride]) / (density1[donor + j * base_stride] * pre_vol[donor + j * vels_wk_stride]);
+          diffuw = energy1[donor + j * base_stride] - energy1[upwind + j * base_stride];
+          diffdw = energy1[downwind + j * base_stride] - energy1[donor + j * base_stride];
+          wind = 1.0;
+          if (diffdw <= 0.0) wind = -1.0;
+          if (diffuw * diffdw > 0.0) {
+            limiter = (1.0 - sigmam) * wind *
+                      fmin(fmin(fabs(diffuw), fabs(diffdw)), one_by_six * (sigma3 * fabs(diffuw) + sigma4 * fabs(diffdw)));
+          } else {
+            limiter = 0.0;
+          }
+          ener_flux[i + j * vels_wk_stride] = mass_flux_x[i + j * flux_x_stride] * (energy1[donor + j * base_stride] + limiter);
+        });
+    }
+
+    // DO k=y_min,y_max
+    //   DO j=x_min,x_max
+
+#pragma omp target teams distribute parallel for simd collapse(2) clover_use_target(use_target)
+    for (int j = (y_min + 1); j < (y_max + 2); j++) {
+      for (int i = (x_min + 1); i < (x_max + 2); i++) {
+        double pre_mass_s = density1[i + j * base_stride] * pre_vol[i + j * vels_wk_stride];
+        double post_mass_s = pre_mass_s + mass_flux_x[i + j * flux_x_stride] - mass_flux_x[(i + 1) + (j + 0) * flux_x_stride];
+        double post_ener_s = (energy1[i + j * base_stride] * pre_mass_s + ener_flux[i + j * vels_wk_stride] -
+                              ener_flux[(i + 1) + (j + 0) * vels_wk_stride]) /
+                             post_mass_s;
+        double advec_vol_s =
+            pre_vol[i + j * vels_wk_stride] + vol_flux_x[i + j * flux_x_stride] - vol_flux_x[(i + 1) + (j + 0) * flux_x_stride];
+        density1[i + j * base_stride] = post_mass_s / advec_vol_s;
+        energy1[i + j * base_stride] = post_ener_s;
+      }
+    }
+
+  } else if (dir == g_ydir) {
+
+    // DO k=y_min-2,y_max+2
+    //   DO j=x_min-2,x_max+2
+
+    if (sweep_number == 1) {
+
+      double *volume = field.volume.data;
+      double *vol_flux_x = field.vol_flux_x.data;
+      double *vol_flux_y = field.vol_flux_y.data;
+      double *pre_vol = field.work_array1.data;
+      double *post_vol = field.work_array2.data;
+
+#pragma omp target teams distribute parallel for simd collapse(2) clover_use_target(use_target)
+      for (int j = (y_min - 2 + 1); j < (y_max + 2 + 2); j++) {
+        for (int i = (x_min - 2 + 1); i < (x_max + 2 + 2); i++) {
+          pre_vol[i + j * vels_wk_stride] =
+              volume[i + j * base_stride] + (vol_flux_y[(i + 0) + (j + 1) * flux_y_stride] - vol_flux_y[i + j * flux_y_stride] +
+                                             vol_flux_x[(i + 1) + (j + 0) * flux_x_stride] - vol_flux_x[i + j * flux_x_stride]);
+          post_vol[i + j * vels_wk_stride] =
+              pre_vol[i + j * vels_wk_stride] - (vol_flux_y[(i + 0) + (j + 1) * flux_y_stride] - vol_flux_y[i + j * flux_y_stride]);
+        }
+      }
+
+    } else {
+
+      double *volume = field.volume.data;
+      double *vol_flux_y = field.vol_flux_y.data;
+      double *pre_vol = field.work_array1.data;
+      double *post_vol = field.work_array2.data;
+
+#pragma omp target teams distribute parallel for simd collapse(2) clover_use_target(use_target)
+      for (int j = (y_min - 2 + 1); j < (y_max + 2 + 2); j++) {
+        for (int i = (x_min - 2 + 1); i < (x_max + 2 + 2); i++) {
+          pre_vol[i + j * vels_wk_stride] =
+              volume[i + j * base_stride] + vol_flux_y[(i + 0) + (j + 1) * flux_y_stride] - vol_flux_y[i + j * flux_y_stride];
+          post_vol[i + j * vels_wk_stride] = volume[i + j * base_stride];
+        }
+      }
+    }
+
+    // DO k=y_min,y_max+2
+    //   DO j=x_min,x_max
+    double *vertexdy = field.vertexdy.data;
+    double *density1 = field.density1.data;
+    double *energy1 = field.energy1.data;
+    double *mass_flux_y = field.mass_flux_y.data;
+    double *vol_flux_y = field.vol_flux_y.data;
+    double *pre_vol = field.work_array1.data;
+    double *ener_flux = field.work_array7.data;
+#pragma omp target teams distribute parallel for simd collapse(2) clover_use_target(use_target)
+    for (int j = (y_min + 1); j < (y_max + 2 + 2); j++) {
+      for (int i = (x_min + 1); i < (x_max + 2); i++)
+        ({
+          int upwind, donor, downwind, dif;
+          double sigmat, sigma3, sigma4, sigmav, sigmam, diffuw, diffdw, limiter, wind;
+          if (vol_flux_y[i + j * flux_y_stride] > 0.0) {
+            upwind = j - 2;
+            donor = j - 1;
+            downwind = j;
+            dif = donor;
+          } else {
+            upwind = MIN(j + 1, y_max + 2);
+            donor = j;
+            downwind = j - 1;
+            dif = upwind;
+          }
+          sigmat = fabs(vol_flux_y[i + j * flux_y_stride]) / pre_vol[i + donor * vels_wk_stride];
+          sigma3 = (1.0 + sigmat) * (vertexdy[j] / vertexdy[dif]);
+          sigma4 = 2.0 - sigmat;
+          //					sigma = sigmat;
+          sigmav = sigmat;
+          diffuw = density1[i + donor * base_stride] - density1[i + upwind * base_stride];
+          diffdw = density1[i + downwind * base_stride] - density1[i + donor * base_stride];
+          wind = 1.0;
+          if (diffdw <= 0.0) wind = -1.0;
+          if (diffuw * diffdw > 0.0) {
+            limiter = (1.0 - sigmav) * wind *
+                      fmin(fmin(fabs(diffuw), fabs(diffdw)), one_by_six * (sigma3 * fabs(diffuw) + sigma4 * fabs(diffdw)));
+          } else {
+            limiter = 0.0;
+          }
+          mass_flux_y[i + j * flux_y_stride] = vol_flux_y[i + j * flux_y_stride] * (density1[i + donor * base_stride] + limiter);
+          sigmam = fabs(mass_flux_y[i + j * flux_y_stride]) / (density1[i + donor * base_stride] * pre_vol[i + donor * vels_wk_stride]);
+          diffuw = energy1[i + donor * base_stride] - energy1[i + upwind * base_stride];
+          diffdw = energy1[i + downwind * base_stride] - energy1[i + donor * base_stride];
+          wind = 1.0;
+          if (diffdw <= 0.0) wind = -1.0;
+          if (diffuw * diffdw > 0.0) {
+            limiter = (1.0 - sigmam) * wind *
+                      fmin(fmin(fabs(diffuw), fabs(diffdw)), one_by_six * (sigma3 * fabs(diffuw) + sigma4 * fabs(diffdw)));
+          } else {
+            limiter = 0.0;
+          }
+          ener_flux[i + j * vels_wk_stride] = mass_flux_y[i + j * flux_y_stride] * (energy1[i + donor * base_stride] + limiter);
+        });
+    }
+
+    // DO k=y_min,y_max
+    //   DO j=x_min,x_max
+
+#pragma omp target teams distribute parallel for simd collapse(2) clover_use_target(use_target)
+    for (int j = (y_min + 1); j < (y_max + 2); j++) {
+      for (int i = (x_min + 1); i < (x_max + 2); i++) {
+        double pre_mass_s = density1[i + j * base_stride] * pre_vol[i + j * vels_wk_stride];
+        double post_mass_s = pre_mass_s + mass_flux_y[i + j * flux_y_stride] - mass_flux_y[(i + 0) + (j + 1) * flux_y_stride];
+        double post_ener_s = (energy1[i + j * base_stride] * pre_mass_s + ener_flux[i + j * vels_wk_stride] -
+                              ener_flux[(i + 0) + (j + 1) * vels_wk_stride]) /
+                             post_mass_s;
+        double advec_vol_s =
+            pre_vol[i + j * vels_wk_stride] + vol_flux_y[i + j * flux_y_stride] - vol_flux_y[(i + 0) + (j + 1) * flux_y_stride];
+        density1[i + j * base_stride] = post_mass_s / advec_vol_s;
+        energy1[i + j * base_stride] = post_ener_s;
+      }
+    }
+  }
+}
+
+//  @brief Cell centred advection driver.
+//  @author Wayne Gaudin
+//  @details Invokes the user selected advection kernel.
+void advec_cell_driver(global_variables &globals, int tile, int sweep_number, int direction) {
+
+#if SYNC_BUFFERS
+  globals.hostToDevice();
+#endif
+
+  tile_type &t = globals.chunk.tiles[tile];
+  advec_cell_kernel(globals.context.use_target, t.info.t_xmin, t.info.t_xmax, t.info.t_ymin, t.info.t_ymax, direction, sweep_number,
+                    t.field);
+
+#if SYNC_BUFFERS
+  globals.deviceToHost();
+#endif
+}

--- a/src/acc/advec_cell.cpp
+++ b/src/acc/advec_cell.cpp
@@ -48,7 +48,10 @@ void advec_cell_kernel(bool use_target, int x_min, int x_max, int y_min, int y_m
       double *pre_vol = field.work_array1.data;
       double *post_vol = field.work_array2.data;
 
-#pragma acc parallel loop gang worker vector default(present) collapse(2) clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector collapse(2) clover_use_target(use_target) \
+    present(volume[ : field.volume.N()], vol_flux_x[ : field.vol_flux_x.N()],            \
+            vol_flux_y[ : field.vol_flux_y.N()], pre_vol[ : field.work_array1.N()],    \
+            post_vol[ : field.work_array2.N()])
       for (int j = (y_min - 2 + 1); j < (y_max + 2 + 2); j++) {
         for (int i = (x_min - 2 + 1); i < (x_max + 2 + 2); i++) {
           pre_vol[i + j * vels_wk_stride] =
@@ -66,7 +69,9 @@ void advec_cell_kernel(bool use_target, int x_min, int x_max, int y_min, int y_m
       double *pre_vol = field.work_array1.data;
       double *post_vol = field.work_array2.data;
 
-#pragma acc parallel loop gang worker vector default(present) collapse(2) clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector collapse(2) clover_use_target(use_target) \
+    present(volume[ : field.volume.N()], vol_flux_x[ : field.vol_flux_x.N()],            \
+            pre_vol[ : field.work_array1.N()], post_vol[ : field.work_array2.N()])
       for (int j = (y_min - 2 + 1); j < (y_max + 2 + 2); j++) {
         for (int i = (x_min - 2 + 1); i < (x_max + 2 + 2); i++) {
           pre_vol[i + j * vels_wk_stride] =
@@ -86,7 +91,11 @@ void advec_cell_kernel(bool use_target, int x_min, int x_max, int y_min, int y_m
     double *pre_vol = field.work_array1.data;
     double *ener_flux = field.work_array7.data;
 
-#pragma acc parallel loop gang worker vector default(present) collapse(2) clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector collapse(2) clover_use_target(use_target) \
+    present(vertexdx[ : field.vertexdx.N()], density1[ : field.density1.N()],          \
+            energy1[ : field.energy1.N()], mass_flux_x[ : field.mass_flux_x.N()],      \
+            vol_flux_x[ : field.vol_flux_x.N()], pre_vol[ : field.work_array1.N()],    \
+            ener_flux[ : field.work_array7.N()])
     for (int j = (y_min + 1); j < (y_max + 2); j++) {
       for (int i = (x_min + 1); i < (x_max + 2 + 2); i++)
         ({
@@ -137,7 +146,11 @@ void advec_cell_kernel(bool use_target, int x_min, int x_max, int y_min, int y_m
     // DO k=y_min,y_max
     //   DO j=x_min,x_max
 
-#pragma acc parallel loop gang worker vector default(present) collapse(2) clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector collapse(2) clover_use_target(use_target) \
+    present(vertexdx[ : field.vertexdx.N()], density1[ : field.density1.N()],          \
+            energy1[ : field.energy1.N()], mass_flux_x[ : field.mass_flux_x.N()],      \
+            vol_flux_x[ : field.vol_flux_x.N()], pre_vol[ : field.work_array1.N()],    \
+            ener_flux[ : field.work_array7.N()])
     for (int j = (y_min + 1); j < (y_max + 2); j++) {
       for (int i = (x_min + 1); i < (x_max + 2); i++) {
         double pre_mass_s = density1[i + j * base_stride] * pre_vol[i + j * vels_wk_stride];
@@ -165,7 +178,10 @@ void advec_cell_kernel(bool use_target, int x_min, int x_max, int y_min, int y_m
       double *pre_vol = field.work_array1.data;
       double *post_vol = field.work_array2.data;
 
-#pragma acc parallel loop gang worker vector default(present) collapse(2) clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector collapse(2) clover_use_target(use_target) \
+      present(post_vol[ : field.work_array2.N()], volume[ : field.volume.N()],         \
+              vol_flux_y[: field.vol_flux_y.N()], vol_flux_x[ : field.vol_flux_x.N()], \
+              pre_vol[ : field.work_array2.N()])
       for (int j = (y_min - 2 + 1); j < (y_max + 2 + 2); j++) {
         for (int i = (x_min - 2 + 1); i < (x_max + 2 + 2); i++) {
           pre_vol[i + j * vels_wk_stride] =
@@ -183,7 +199,9 @@ void advec_cell_kernel(bool use_target, int x_min, int x_max, int y_min, int y_m
       double *pre_vol = field.work_array1.data;
       double *post_vol = field.work_array2.data;
 
-#pragma acc parallel loop gang worker vector default(present) collapse(2) clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector collapse(2) clover_use_target(use_target) \
+      present(post_vol[ : field.work_array2.N()], volume[ : field.volume.N()],         \
+              vol_flux_y[: field.vol_flux_y.N()], pre_vol[ : field.work_array2.N()])
       for (int j = (y_min - 2 + 1); j < (y_max + 2 + 2); j++) {
         for (int i = (x_min - 2 + 1); i < (x_max + 2 + 2); i++) {
           pre_vol[i + j * vels_wk_stride] =
@@ -202,7 +220,11 @@ void advec_cell_kernel(bool use_target, int x_min, int x_max, int y_min, int y_m
     double *vol_flux_y = field.vol_flux_y.data;
     double *pre_vol = field.work_array1.data;
     double *ener_flux = field.work_array7.data;
-#pragma acc parallel loop gang worker vector default(present) collapse(2) clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector collapse(2) clover_use_target(use_target) \
+    present(vertexdy[ : field.vertexdy.N()], density1[ : field.density1.N()],          \
+            energy1[ : field.energy1.N()], mass_flux_y[ : field.mass_flux_y.N()],      \
+            vol_flux_y[ : field.vol_flux_y.N()], pre_vol[ : field.work_array1.N()],    \
+            ener_flux[ : field.work_array7.N()])
     for (int j = (y_min + 1); j < (y_max + 2 + 2); j++) {
       for (int i = (x_min + 1); i < (x_max + 2); i++)
         ({
@@ -253,7 +275,11 @@ void advec_cell_kernel(bool use_target, int x_min, int x_max, int y_min, int y_m
     // DO k=y_min,y_max
     //   DO j=x_min,x_max
 
-#pragma acc parallel loop gang worker vector default(present) collapse(2) clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector collapse(2) clover_use_target(use_target) \
+    present(vertexdy[ : field.vertexdy.N()], density1[ : field.density1.N()],          \
+            energy1[ : field.energy1.N()], mass_flux_y[ : field.mass_flux_y.N()],      \
+            vol_flux_y[ : field.vol_flux_y.N()], pre_vol[ : field.work_array1.N()],    \
+            ener_flux[ : field.work_array7.N()])
     for (int j = (y_min + 1); j < (y_max + 2); j++) {
       for (int i = (x_min + 1); i < (x_max + 2); i++) {
         double pre_mass_s = density1[i + j * base_stride] * pre_vol[i + j * vels_wk_stride];

--- a/src/acc/advec_cell.cpp
+++ b/src/acc/advec_cell.cpp
@@ -48,7 +48,7 @@ void advec_cell_kernel(bool use_target, int x_min, int x_max, int y_min, int y_m
       double *pre_vol = field.work_array1.data;
       double *post_vol = field.work_array2.data;
 
-#pragma omp target teams distribute parallel for simd collapse(2) clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector default(present) collapse(2) clover_use_target(use_target)
       for (int j = (y_min - 2 + 1); j < (y_max + 2 + 2); j++) {
         for (int i = (x_min - 2 + 1); i < (x_max + 2 + 2); i++) {
           pre_vol[i + j * vels_wk_stride] =
@@ -66,7 +66,7 @@ void advec_cell_kernel(bool use_target, int x_min, int x_max, int y_min, int y_m
       double *pre_vol = field.work_array1.data;
       double *post_vol = field.work_array2.data;
 
-#pragma omp target teams distribute parallel for simd collapse(2) clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector default(present) collapse(2) clover_use_target(use_target)
       for (int j = (y_min - 2 + 1); j < (y_max + 2 + 2); j++) {
         for (int i = (x_min - 2 + 1); i < (x_max + 2 + 2); i++) {
           pre_vol[i + j * vels_wk_stride] =
@@ -86,7 +86,7 @@ void advec_cell_kernel(bool use_target, int x_min, int x_max, int y_min, int y_m
     double *pre_vol = field.work_array1.data;
     double *ener_flux = field.work_array7.data;
 
-#pragma omp target teams distribute parallel for simd collapse(2) clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector default(present) collapse(2) clover_use_target(use_target)
     for (int j = (y_min + 1); j < (y_max + 2); j++) {
       for (int i = (x_min + 1); i < (x_max + 2 + 2); i++)
         ({
@@ -137,7 +137,7 @@ void advec_cell_kernel(bool use_target, int x_min, int x_max, int y_min, int y_m
     // DO k=y_min,y_max
     //   DO j=x_min,x_max
 
-#pragma omp target teams distribute parallel for simd collapse(2) clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector default(present) collapse(2) clover_use_target(use_target)
     for (int j = (y_min + 1); j < (y_max + 2); j++) {
       for (int i = (x_min + 1); i < (x_max + 2); i++) {
         double pre_mass_s = density1[i + j * base_stride] * pre_vol[i + j * vels_wk_stride];
@@ -165,7 +165,7 @@ void advec_cell_kernel(bool use_target, int x_min, int x_max, int y_min, int y_m
       double *pre_vol = field.work_array1.data;
       double *post_vol = field.work_array2.data;
 
-#pragma omp target teams distribute parallel for simd collapse(2) clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector default(present) collapse(2) clover_use_target(use_target)
       for (int j = (y_min - 2 + 1); j < (y_max + 2 + 2); j++) {
         for (int i = (x_min - 2 + 1); i < (x_max + 2 + 2); i++) {
           pre_vol[i + j * vels_wk_stride] =
@@ -183,7 +183,7 @@ void advec_cell_kernel(bool use_target, int x_min, int x_max, int y_min, int y_m
       double *pre_vol = field.work_array1.data;
       double *post_vol = field.work_array2.data;
 
-#pragma omp target teams distribute parallel for simd collapse(2) clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector default(present) collapse(2) clover_use_target(use_target)
       for (int j = (y_min - 2 + 1); j < (y_max + 2 + 2); j++) {
         for (int i = (x_min - 2 + 1); i < (x_max + 2 + 2); i++) {
           pre_vol[i + j * vels_wk_stride] =
@@ -202,7 +202,7 @@ void advec_cell_kernel(bool use_target, int x_min, int x_max, int y_min, int y_m
     double *vol_flux_y = field.vol_flux_y.data;
     double *pre_vol = field.work_array1.data;
     double *ener_flux = field.work_array7.data;
-#pragma omp target teams distribute parallel for simd collapse(2) clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector default(present) collapse(2) clover_use_target(use_target)
     for (int j = (y_min + 1); j < (y_max + 2 + 2); j++) {
       for (int i = (x_min + 1); i < (x_max + 2); i++)
         ({
@@ -253,7 +253,7 @@ void advec_cell_kernel(bool use_target, int x_min, int x_max, int y_min, int y_m
     // DO k=y_min,y_max
     //   DO j=x_min,x_max
 
-#pragma omp target teams distribute parallel for simd collapse(2) clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector default(present) collapse(2) clover_use_target(use_target)
     for (int j = (y_min + 1); j < (y_max + 2); j++) {
       for (int i = (x_min + 1); i < (x_max + 2); i++) {
         double pre_mass_s = density1[i + j * base_stride] * pre_vol[i + j * vels_wk_stride];

--- a/src/acc/advec_mom.cpp
+++ b/src/acc/advec_mom.cpp
@@ -1,0 +1,323 @@
+/*
+ Crown Copyright 2012 AWE.
+
+ This file is part of CloverLeaf.
+
+ CloverLeaf is free software: you can redistribute it and/or modify it under
+ the terms of the GNU General Public License as published by the
+ Free Software Foundation, either version 3 of the License, or (at your option)
+ any later version.
+
+ CloverLeaf is distributed in the hope that it will be useful, but
+ WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ details.
+
+ You should have received a copy of the GNU General Public License along with
+ CloverLeaf. If not, see http://www.gnu.org/licenses/.
+ */
+
+#include "advec_mom.h"
+#include <cmath>
+
+//  @brief Fortran momentum advection kernel
+//  @author Wayne Gaudin
+//  @details Performs a second order advective remap on the vertex momentum
+//  using van-Leer limiting and directional splitting.
+//  Note that although pre_vol is only set and not used in the update, please
+//  leave it in the method.
+void advec_mom_kernel(bool use_target, int x_min, int x_max, int y_min, int y_max, clover::Buffer2D<double> &vel1_buffer, field_type &field,
+                      int which_vel, int sweep_number, int direction) {
+
+  int mom_sweep = direction + 2 * (sweep_number - 1);
+
+  // DO k=y_min-2,y_max+2
+  //   DO j=x_min-2,x_max+2
+
+  const int base_stride = field.base_stride;
+  const int vels_wk_stride = field.vels_wk_stride;
+  const int flux_x_stride = field.flux_x_stride;
+  const int flux_y_stride = field.flux_y_stride;
+
+  if (mom_sweep == 1) { // x 1
+
+    double *vol_flux_y = field.vol_flux_y.data;
+    double *vol_flux_x = field.vol_flux_x.data;
+    double *volume = field.volume.data;
+    double *pre_vol = field.work_array5.data;
+    double *post_vol = field.work_array6.data;
+
+#pragma omp target teams distribute parallel for simd collapse(2) clover_use_target(use_target)
+    for (int j = (y_min - 2 + 1); j < (y_max + 2 + 2); j++) {
+      for (int i = (x_min - 2 + 1); i < (x_max + 2 + 2); i++) {
+        post_vol[i + j * vels_wk_stride] =
+            volume[i + j * base_stride] + vol_flux_y[(i + 0) + (j + 1) * flux_y_stride] - vol_flux_y[i + j * flux_y_stride];
+        pre_vol[i + j * vels_wk_stride] =
+            post_vol[i + j * vels_wk_stride] + vol_flux_x[(i + 1) + (j + 0) * flux_x_stride] - vol_flux_x[i + j * flux_x_stride];
+      }
+    }
+  } else if (mom_sweep == 2) { // y 1
+
+    double *vol_flux_y = field.vol_flux_y.data;
+    double *vol_flux_x = field.vol_flux_x.data;
+    double *volume = field.volume.data;
+    double *pre_vol = field.work_array5.data;
+    double *post_vol = field.work_array6.data;
+
+#pragma omp target teams distribute parallel for simd collapse(2) clover_use_target(use_target)
+    for (int j = (y_min - 2 + 1); j < (y_max + 2 + 2); j++) {
+      for (int i = (x_min - 2 + 1); i < (x_max + 2 + 2); i++) {
+        post_vol[i + j * vels_wk_stride] =
+            volume[i + j * base_stride] + vol_flux_x[(i + 1) + (j + 0) * flux_x_stride] - vol_flux_x[i + j * flux_x_stride];
+        pre_vol[i + j * vels_wk_stride] =
+            post_vol[i + j * vels_wk_stride] + vol_flux_y[(i + 0) + (j + 1) * flux_y_stride] - vol_flux_y[i + j * flux_y_stride];
+      }
+    }
+  } else if (mom_sweep == 3) { // x 2
+
+    double *vol_flux_y = field.vol_flux_y.data;
+    double *volume = field.volume.data;
+    double *pre_vol = field.work_array5.data;
+    double *post_vol = field.work_array6.data;
+
+#pragma omp target teams distribute parallel for simd collapse(2) clover_use_target(use_target)
+    for (int j = (y_min - 2 + 1); j < (y_max + 2 + 2); j++) {
+      for (int i = (x_min - 2 + 1); i < (x_max + 2 + 2); i++) {
+        post_vol[i + j * vels_wk_stride] = volume[i + j * base_stride];
+        pre_vol[i + j * vels_wk_stride] =
+            post_vol[i + j * vels_wk_stride] + vol_flux_y[(i + 0) + (j + 1) * flux_y_stride] - vol_flux_y[i + j * flux_y_stride];
+      }
+    }
+  } else if (mom_sweep == 4) { // y 2
+
+    double *vol_flux_x = field.vol_flux_x.data;
+    double *volume = field.volume.data;
+    double *pre_vol = field.work_array5.data;
+    double *post_vol = field.work_array6.data;
+
+#pragma omp target teams distribute parallel for simd collapse(2) clover_use_target(use_target)
+    for (int j = (y_min - 2 + 1); j < (y_max + 2 + 2); j++) {
+      for (int i = (x_min - 2 + 1); i < (x_max + 2 + 2); i++) {
+        post_vol[i + j * vels_wk_stride] = volume[i + j * base_stride];
+        pre_vol[i + j * vels_wk_stride] =
+            post_vol[i + j * vels_wk_stride] + vol_flux_x[(i + 1) + (j + 0) * flux_x_stride] - vol_flux_x[i + j * flux_x_stride];
+      }
+    }
+  }
+
+  if (direction == 1) {
+    if (which_vel == 1) {
+      // DO k=y_min,y_max+1
+      //   DO j=x_min-2,x_max+2
+
+      double *mass_flux_x = field.mass_flux_x.data;
+      double *node_flux = field.work_array1.data;
+
+#pragma omp target teams distribute parallel for simd collapse(2) clover_use_target(use_target)
+      for (int j = (y_min + 1); j < (y_max + 1 + 2); j++) {
+        for (int i = (x_min - 2 + 1); i < (x_max + 2 + 2); i++) {
+          node_flux[i + j * vels_wk_stride] =
+              0.25 * (mass_flux_x[(i + 0) + (j - 1) * flux_x_stride] + mass_flux_x[i + j * flux_x_stride] +
+                      mass_flux_x[(i + 1) + (j - 1) * flux_x_stride] + mass_flux_x[(i + 1) + (j + 0) * flux_x_stride]);
+        }
+      }
+
+      // DO k=y_min,y_max+1
+      //   DO j=x_min-1,x_max+2
+
+      double *density1 = field.density1.data;
+      double *node_mass_post = field.work_array2.data;
+      double *node_mass_pre = field.work_array3.data;
+      double *post_vol = field.work_array6.data;
+
+#pragma omp target teams distribute parallel for simd collapse(2) clover_use_target(use_target)
+      for (int j = (y_min + 1); j < (y_max + 1 + 2); j++) {
+        for (int i = (x_min - 1 + 1); i < (x_max + 2 + 2); i++) {
+          node_mass_post[i + j * vels_wk_stride] =
+              0.25 * (density1[(i + 0) + (j - 1) * base_stride] * post_vol[(i + 0) + (j - 1) * vels_wk_stride] +
+                      density1[i + j * base_stride] * post_vol[i + j * vels_wk_stride] +
+                      density1[(i - 1) + (j - 1) * base_stride] * post_vol[(i - 1) + (j - 1) * vels_wk_stride] +
+                      density1[(i - 1) + (j + 0) * base_stride] * post_vol[(i - 1) + (j + 0) * vels_wk_stride]);
+          node_mass_pre[i + j * vels_wk_stride] =
+              node_mass_post[i + j * vels_wk_stride] - node_flux[(i - 1) + (j + 0) * vels_wk_stride] + node_flux[i + j * vels_wk_stride];
+        }
+      }
+    }
+
+    // DO k=y_min,y_max+1
+    //  DO j=x_min-1,x_max+1
+
+    const size_t vel1_sizex = vel1_buffer.nX();
+    double *vel1 = vel1_buffer.data;
+    double *node_flux = field.work_array1.data;
+    double *node_mass_pre = field.work_array3.data;
+    double *mom_flux = field.work_array4.data;
+    double *celldx = field.celldx.data;
+
+#pragma omp target teams distribute parallel for simd collapse(2) clover_use_target(use_target)
+    for (int j = (y_min + 1); j < (y_max + 1 + 2); j++) {
+      for (int i = (x_min - 1 + 1); i < (x_max + 1 + 2); i++)
+        ({
+          int upwind, donor, downwind, dif;
+          double sigma, width, limiter, vdiffuw, vdiffdw, auw, adw, wind, advec_vel_s;
+          if (node_flux[i + j * vels_wk_stride] < 0.0) {
+            upwind = i + 2;
+            donor = i + 1;
+            downwind = i;
+            dif = donor;
+          } else {
+            upwind = i - 1;
+            donor = i;
+            downwind = i + 1;
+            dif = upwind;
+          }
+          sigma = fabs(node_flux[i + j * vels_wk_stride]) / (node_mass_pre[donor + j * vels_wk_stride]);
+          width = celldx[i];
+          vdiffuw = vel1[donor + j * vel1_sizex] - vel1[upwind + j * vel1_sizex];
+          vdiffdw = vel1[downwind + j * vel1_sizex] - vel1[donor + j * vel1_sizex];
+          limiter = 0.0;
+          if (vdiffuw * vdiffdw > 0.0) {
+            auw = fabs(vdiffuw);
+            adw = fabs(vdiffdw);
+            wind = 1.0;
+            if (vdiffdw <= 0.0) wind = -1.0;
+            limiter = wind * fmin(fmin(width * ((2.0 - sigma) * adw / width + (1.0 + sigma) * auw / celldx[dif]) / 6.0, auw), adw);
+          }
+          advec_vel_s = vel1[donor + j * vel1_sizex] + (1.0 - sigma) * limiter;
+          mom_flux[i + j * vels_wk_stride] = advec_vel_s * node_flux[i + j * vels_wk_stride];
+        });
+    }
+
+    // DO k=y_min,y_max+1
+    //   DO j=x_min,x_max+1
+
+    double *node_mass_post = field.work_array2.data;
+
+#pragma omp target teams distribute parallel for simd collapse(2) clover_use_target(use_target)
+    for (int j = (y_min + 1); j < (y_max + 1 + 2); j++) {
+      for (int i = (x_min + 1); i < (x_max + 1 + 2); i++) {
+        vel1[i + j * vel1_sizex] = (vel1[i + j * vel1_sizex] * node_mass_pre[i + j * vels_wk_stride] +
+                                    mom_flux[(i - 1) + (j + 0) * vels_wk_stride] - mom_flux[i + j * vels_wk_stride]) /
+                                   node_mass_post[i + j * vels_wk_stride];
+      }
+    }
+  } else if (direction == 2) {
+    if (which_vel == 1) {
+      // DO k=y_min-2,y_max+2
+      //   DO j=x_min,x_max+1
+
+      double *node_flux = field.work_array1.data;
+      double *mass_flux_y = field.mass_flux_y.data;
+
+#pragma omp target teams distribute parallel for simd collapse(2) clover_use_target(use_target)
+      for (int j = (y_min - 2 + 1); j < (y_max + 2 + 2); j++) {
+        for (int i = (x_min + 1); i < (x_max + 1 + 2); i++) {
+          node_flux[i + j * vels_wk_stride] =
+              0.25 * (mass_flux_y[(i - 1) + (j + 0) * flux_y_stride] + mass_flux_y[i + j * flux_y_stride] +
+                      mass_flux_y[(i - 1) + (j + 1) * flux_y_stride] + mass_flux_y[(i + 0) + (j + 1) * flux_y_stride]);
+        }
+      }
+
+      // DO k=y_min-1,y_max+2
+      //   DO j=x_min,x_max+1
+      double *density1 = field.density1.data;
+      double *node_mass_post = field.work_array2.data;
+      double *node_mass_pre = field.work_array3.data;
+      double *post_vol = field.work_array6.data;
+
+#pragma omp target teams distribute parallel for simd collapse(2) clover_use_target(use_target)
+      for (int j = (y_min - 1 + 1); j < (y_max + 2 + 2); j++) {
+        for (int i = (x_min + 1); i < (x_max + 1 + 2); i++) {
+          node_mass_post[i + j * vels_wk_stride] =
+              0.25 * (density1[(i + 0) + (j - 1) * base_stride] * post_vol[(i + 0) + (j - 1) * vels_wk_stride] +
+                      density1[i + j * base_stride] * post_vol[i + j * vels_wk_stride] +
+                      density1[(i - 1) + (j - 1) * base_stride] * post_vol[(i - 1) + (j - 1) * vels_wk_stride] +
+                      density1[(i - 1) + (j + 0) * base_stride] * post_vol[(i - 1) + (j + 0) * vels_wk_stride]);
+          node_mass_pre[i + j * vels_wk_stride] =
+              node_mass_post[i + j * vels_wk_stride] - node_flux[(i + 0) + (j - 1) * vels_wk_stride] + node_flux[i + j * vels_wk_stride];
+        }
+      }
+    }
+
+    // DO k=y_min-1,y_max+1
+    //   DO j=x_min,x_max+1
+
+    const size_t vel1_sizex = vel1_buffer.nX();
+    double *vel1 = vel1_buffer.data;
+    double *node_flux = field.work_array1.data;
+    double *node_mass_pre = field.work_array3.data;
+    double *mom_flux = field.work_array4.data;
+    double *celldy = field.celldy.data;
+
+#pragma omp target teams distribute parallel for simd collapse(2) clover_use_target(use_target)
+    for (int j = (y_min - 1 + 1); j < (y_max + 1 + 2); j++) {
+      for (int i = (x_min + 1); i < (x_max + 1 + 2); i++)
+        ({
+          int upwind, donor, downwind, dif;
+          double sigma, width, limiter, vdiffuw, vdiffdw, auw, adw, wind, advec_vel_s;
+          if (node_flux[i + j * vels_wk_stride] < 0.0) {
+            upwind = j + 2;
+            donor = j + 1;
+            downwind = j;
+            dif = donor;
+          } else {
+            upwind = j - 1;
+            donor = j;
+            downwind = j + 1;
+            dif = upwind;
+          }
+          sigma = fabs(node_flux[i + j * vels_wk_stride]) / (node_mass_pre[i + donor * vels_wk_stride]);
+          width = celldy[j];
+          vdiffuw = vel1[i + donor * vel1_sizex] - vel1[i + upwind * vel1_sizex];
+          vdiffdw = vel1[i + downwind * vel1_sizex] - vel1[i + donor * vel1_sizex];
+          limiter = 0.0;
+          if (vdiffuw * vdiffdw > 0.0) {
+            auw = fabs(vdiffuw);
+            adw = fabs(vdiffdw);
+            wind = 1.0;
+            if (vdiffdw <= 0.0) wind = -1.0;
+            limiter = wind * fmin(fmin(width * ((2.0 - sigma) * adw / width + (1.0 + sigma) * auw / celldy[dif]) / 6.0, auw), adw);
+          }
+          advec_vel_s = vel1[i + donor * vel1_sizex] + (1.0 - sigma) * limiter;
+          mom_flux[i + j * vels_wk_stride] = advec_vel_s * node_flux[i + j * vels_wk_stride];
+        });
+    }
+
+    // DO k=y_min,y_max+1
+    //   DO j=x_min,x_max+1
+
+    double *node_mass_post = field.work_array2.data;
+
+#pragma omp target teams distribute parallel for simd collapse(2) clover_use_target(use_target)
+    for (int j = (y_min + 1); j < (y_max + 1 + 2); j++) {
+      for (int i = (x_min + 1); i < (x_max + 1 + 2); i++) {
+        vel1[i + j * vel1_sizex] = (vel1[i + j * vel1_sizex] * node_mass_pre[i + j * vels_wk_stride] +
+                                    mom_flux[(i + 0) + (j - 1) * vels_wk_stride] - mom_flux[i + j * vels_wk_stride]) /
+                                   node_mass_post[i + j * vels_wk_stride];
+      }
+    }
+  }
+}
+
+//  @brief Momentum advection driver
+//  @author Wayne Gaudin
+//  @details Invokes the user specified momentum advection kernel.
+void advec_mom_driver(global_variables &globals, int tile, int which_vel, int direction, int sweep_number) {
+
+#if SYNC_BUFFERS
+  globals.hostToDevice();
+#endif
+
+  tile_type &t = globals.chunk.tiles[tile];
+  if (which_vel == 1) {
+    advec_mom_kernel(globals.context.use_target, t.info.t_xmin, t.info.t_xmax, t.info.t_ymin, t.info.t_ymax, t.field.xvel1, t.field,
+                     which_vel, sweep_number, direction);
+  } else {
+    advec_mom_kernel(globals.context.use_target, t.info.t_xmin, t.info.t_xmax, t.info.t_ymin, t.info.t_ymax, t.field.yvel1, t.field,
+                     which_vel, sweep_number, direction);
+  }
+
+#if SYNC_BUFFERS
+  globals.deviceToHost();
+#endif
+}

--- a/src/acc/advec_mom.cpp
+++ b/src/acc/advec_mom.cpp
@@ -47,7 +47,7 @@ void advec_mom_kernel(bool use_target, int x_min, int x_max, int y_min, int y_ma
     double *pre_vol = field.work_array5.data;
     double *post_vol = field.work_array6.data;
 
-#pragma omp target teams distribute parallel for simd collapse(2) clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector default(present) collapse(2) clover_use_target(use_target)
     for (int j = (y_min - 2 + 1); j < (y_max + 2 + 2); j++) {
       for (int i = (x_min - 2 + 1); i < (x_max + 2 + 2); i++) {
         post_vol[i + j * vels_wk_stride] =
@@ -64,7 +64,7 @@ void advec_mom_kernel(bool use_target, int x_min, int x_max, int y_min, int y_ma
     double *pre_vol = field.work_array5.data;
     double *post_vol = field.work_array6.data;
 
-#pragma omp target teams distribute parallel for simd collapse(2) clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector default(present) collapse(2) clover_use_target(use_target)
     for (int j = (y_min - 2 + 1); j < (y_max + 2 + 2); j++) {
       for (int i = (x_min - 2 + 1); i < (x_max + 2 + 2); i++) {
         post_vol[i + j * vels_wk_stride] =
@@ -80,7 +80,7 @@ void advec_mom_kernel(bool use_target, int x_min, int x_max, int y_min, int y_ma
     double *pre_vol = field.work_array5.data;
     double *post_vol = field.work_array6.data;
 
-#pragma omp target teams distribute parallel for simd collapse(2) clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector default(present) collapse(2) clover_use_target(use_target)
     for (int j = (y_min - 2 + 1); j < (y_max + 2 + 2); j++) {
       for (int i = (x_min - 2 + 1); i < (x_max + 2 + 2); i++) {
         post_vol[i + j * vels_wk_stride] = volume[i + j * base_stride];
@@ -95,7 +95,7 @@ void advec_mom_kernel(bool use_target, int x_min, int x_max, int y_min, int y_ma
     double *pre_vol = field.work_array5.data;
     double *post_vol = field.work_array6.data;
 
-#pragma omp target teams distribute parallel for simd collapse(2) clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector default(present) collapse(2) clover_use_target(use_target)
     for (int j = (y_min - 2 + 1); j < (y_max + 2 + 2); j++) {
       for (int i = (x_min - 2 + 1); i < (x_max + 2 + 2); i++) {
         post_vol[i + j * vels_wk_stride] = volume[i + j * base_stride];
@@ -113,7 +113,7 @@ void advec_mom_kernel(bool use_target, int x_min, int x_max, int y_min, int y_ma
       double *mass_flux_x = field.mass_flux_x.data;
       double *node_flux = field.work_array1.data;
 
-#pragma omp target teams distribute parallel for simd collapse(2) clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector default(present) collapse(2) clover_use_target(use_target)
       for (int j = (y_min + 1); j < (y_max + 1 + 2); j++) {
         for (int i = (x_min - 2 + 1); i < (x_max + 2 + 2); i++) {
           node_flux[i + j * vels_wk_stride] =
@@ -130,7 +130,7 @@ void advec_mom_kernel(bool use_target, int x_min, int x_max, int y_min, int y_ma
       double *node_mass_pre = field.work_array3.data;
       double *post_vol = field.work_array6.data;
 
-#pragma omp target teams distribute parallel for simd collapse(2) clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector default(present) collapse(2) clover_use_target(use_target)
       for (int j = (y_min + 1); j < (y_max + 1 + 2); j++) {
         for (int i = (x_min - 1 + 1); i < (x_max + 2 + 2); i++) {
           node_mass_post[i + j * vels_wk_stride] =
@@ -154,7 +154,7 @@ void advec_mom_kernel(bool use_target, int x_min, int x_max, int y_min, int y_ma
     double *mom_flux = field.work_array4.data;
     double *celldx = field.celldx.data;
 
-#pragma omp target teams distribute parallel for simd collapse(2) clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector default(present) collapse(2) clover_use_target(use_target)
     for (int j = (y_min + 1); j < (y_max + 1 + 2); j++) {
       for (int i = (x_min - 1 + 1); i < (x_max + 1 + 2); i++)
         ({
@@ -193,7 +193,7 @@ void advec_mom_kernel(bool use_target, int x_min, int x_max, int y_min, int y_ma
 
     double *node_mass_post = field.work_array2.data;
 
-#pragma omp target teams distribute parallel for simd collapse(2) clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector default(present) collapse(2) clover_use_target(use_target)
     for (int j = (y_min + 1); j < (y_max + 1 + 2); j++) {
       for (int i = (x_min + 1); i < (x_max + 1 + 2); i++) {
         vel1[i + j * vel1_sizex] = (vel1[i + j * vel1_sizex] * node_mass_pre[i + j * vels_wk_stride] +
@@ -209,7 +209,7 @@ void advec_mom_kernel(bool use_target, int x_min, int x_max, int y_min, int y_ma
       double *node_flux = field.work_array1.data;
       double *mass_flux_y = field.mass_flux_y.data;
 
-#pragma omp target teams distribute parallel for simd collapse(2) clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector default(present) collapse(2) clover_use_target(use_target)
       for (int j = (y_min - 2 + 1); j < (y_max + 2 + 2); j++) {
         for (int i = (x_min + 1); i < (x_max + 1 + 2); i++) {
           node_flux[i + j * vels_wk_stride] =
@@ -225,7 +225,7 @@ void advec_mom_kernel(bool use_target, int x_min, int x_max, int y_min, int y_ma
       double *node_mass_pre = field.work_array3.data;
       double *post_vol = field.work_array6.data;
 
-#pragma omp target teams distribute parallel for simd collapse(2) clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector default(present) collapse(2) clover_use_target(use_target)
       for (int j = (y_min - 1 + 1); j < (y_max + 2 + 2); j++) {
         for (int i = (x_min + 1); i < (x_max + 1 + 2); i++) {
           node_mass_post[i + j * vels_wk_stride] =
@@ -249,7 +249,7 @@ void advec_mom_kernel(bool use_target, int x_min, int x_max, int y_min, int y_ma
     double *mom_flux = field.work_array4.data;
     double *celldy = field.celldy.data;
 
-#pragma omp target teams distribute parallel for simd collapse(2) clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector default(present) collapse(2) clover_use_target(use_target)
     for (int j = (y_min - 1 + 1); j < (y_max + 1 + 2); j++) {
       for (int i = (x_min + 1); i < (x_max + 1 + 2); i++)
         ({
@@ -288,7 +288,7 @@ void advec_mom_kernel(bool use_target, int x_min, int x_max, int y_min, int y_ma
 
     double *node_mass_post = field.work_array2.data;
 
-#pragma omp target teams distribute parallel for simd collapse(2) clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector default(present) collapse(2) clover_use_target(use_target)
     for (int j = (y_min + 1); j < (y_max + 1 + 2); j++) {
       for (int i = (x_min + 1); i < (x_max + 1 + 2); i++) {
         vel1[i + j * vel1_sizex] = (vel1[i + j * vel1_sizex] * node_mass_pre[i + j * vels_wk_stride] +

--- a/src/acc/advec_mom.cpp
+++ b/src/acc/advec_mom.cpp
@@ -47,7 +47,10 @@ void advec_mom_kernel(bool use_target, int x_min, int x_max, int y_min, int y_ma
     double *pre_vol = field.work_array5.data;
     double *post_vol = field.work_array6.data;
 
-#pragma acc parallel loop gang worker vector default(present) collapse(2) clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector collapse(2) clover_use_target(use_target) \
+    present(vol_flux_y[ : field.vol_flux_y.N()], vol_flux_x[ : field.vol_flux_x.N()],  \
+            volume[ : field.volume.N()], pre_vol[ : field.work_array5.N()],            \
+            post_vol[ : field.work_array6.N()])
     for (int j = (y_min - 2 + 1); j < (y_max + 2 + 2); j++) {
       for (int i = (x_min - 2 + 1); i < (x_max + 2 + 2); i++) {
         post_vol[i + j * vels_wk_stride] =
@@ -64,7 +67,10 @@ void advec_mom_kernel(bool use_target, int x_min, int x_max, int y_min, int y_ma
     double *pre_vol = field.work_array5.data;
     double *post_vol = field.work_array6.data;
 
-#pragma acc parallel loop gang worker vector default(present) collapse(2) clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector collapse(2) clover_use_target(use_target) \
+    present(vol_flux_y[ : field.vol_flux_y.N()], vol_flux_x[ : field.vol_flux_x.N()],  \
+            volume[ : field.volume.N()], pre_vol[ : field.work_array5.N()],            \
+            post_vol[ : field.work_array6.N()])
     for (int j = (y_min - 2 + 1); j < (y_max + 2 + 2); j++) {
       for (int i = (x_min - 2 + 1); i < (x_max + 2 + 2); i++) {
         post_vol[i + j * vels_wk_stride] =
@@ -80,7 +86,9 @@ void advec_mom_kernel(bool use_target, int x_min, int x_max, int y_min, int y_ma
     double *pre_vol = field.work_array5.data;
     double *post_vol = field.work_array6.data;
 
-#pragma acc parallel loop gang worker vector default(present) collapse(2) clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector collapse(2) clover_use_target(use_target) \
+    present(vol_flux_y[ : field.vol_flux_y.N()], volume[ : field.volume.N()],          \
+            pre_vol[ : field.work_array5.N()], post_vol[ : field.work_array6.N()])
     for (int j = (y_min - 2 + 1); j < (y_max + 2 + 2); j++) {
       for (int i = (x_min - 2 + 1); i < (x_max + 2 + 2); i++) {
         post_vol[i + j * vels_wk_stride] = volume[i + j * base_stride];
@@ -95,7 +103,9 @@ void advec_mom_kernel(bool use_target, int x_min, int x_max, int y_min, int y_ma
     double *pre_vol = field.work_array5.data;
     double *post_vol = field.work_array6.data;
 
-#pragma acc parallel loop gang worker vector default(present) collapse(2) clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector collapse(2) clover_use_target(use_target) \
+    present(vol_flux_x[ : field.vol_flux_x.N()], volume[ : field.volume.N()],          \
+            pre_vol[ : field.work_array5.N()], post_vol[ : field.work_array6.N()])
     for (int j = (y_min - 2 + 1); j < (y_max + 2 + 2); j++) {
       for (int i = (x_min - 2 + 1); i < (x_max + 2 + 2); i++) {
         post_vol[i + j * vels_wk_stride] = volume[i + j * base_stride];
@@ -113,7 +123,8 @@ void advec_mom_kernel(bool use_target, int x_min, int x_max, int y_min, int y_ma
       double *mass_flux_x = field.mass_flux_x.data;
       double *node_flux = field.work_array1.data;
 
-#pragma acc parallel loop gang worker vector default(present) collapse(2) clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector collapse(2) clover_use_target(use_target) \
+    present(mass_flux_x[ : field.mass_flux_x.N()], node_flux[ : field.work_array1.N()]) 
       for (int j = (y_min + 1); j < (y_max + 1 + 2); j++) {
         for (int i = (x_min - 2 + 1); i < (x_max + 2 + 2); i++) {
           node_flux[i + j * vels_wk_stride] =
@@ -130,7 +141,10 @@ void advec_mom_kernel(bool use_target, int x_min, int x_max, int y_min, int y_ma
       double *node_mass_pre = field.work_array3.data;
       double *post_vol = field.work_array6.data;
 
-#pragma acc parallel loop gang worker vector default(present) collapse(2) clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector collapse(2) clover_use_target(use_target)   \
+    present(density1[ : field.density1.N()], node_mass_post[ : field.work_array2.N()],   \
+            node_mass_pre[ : field.work_array3.N()], post_vol[ : field.work_array6.N()], \
+            node_flux[ : field.work_array1.N()])
       for (int j = (y_min + 1); j < (y_max + 1 + 2); j++) {
         for (int i = (x_min - 1 + 1); i < (x_max + 2 + 2); i++) {
           node_mass_post[i + j * vels_wk_stride] =
@@ -154,7 +168,10 @@ void advec_mom_kernel(bool use_target, int x_min, int x_max, int y_min, int y_ma
     double *mom_flux = field.work_array4.data;
     double *celldx = field.celldx.data;
 
-#pragma acc parallel loop gang worker vector default(present) collapse(2) clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector collapse(2) clover_use_target(use_target)   \
+    present(vel1[ : vel1_buffer.N()], node_flux[ : field.work_array1.N()],               \
+            node_mass_pre[ : field.work_array3.N()], mom_flux[ : field.work_array4.N()], \
+            celldx[ : field.celldx.N()])
     for (int j = (y_min + 1); j < (y_max + 1 + 2); j++) {
       for (int i = (x_min - 1 + 1); i < (x_max + 1 + 2); i++)
         ({
@@ -193,7 +210,10 @@ void advec_mom_kernel(bool use_target, int x_min, int x_max, int y_min, int y_ma
 
     double *node_mass_post = field.work_array2.data;
 
-#pragma acc parallel loop gang worker vector default(present) collapse(2) clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector collapse(2) clover_use_target(use_target)   \
+    present(vel1[ : vel1_buffer.N()], node_mass_pre[ : field.work_array3.N()],           \
+            mom_flux[ : field.work_array4.N()], celldx[ : field.celldx.N()],             \
+            node_mass_post[ : field.work_array2.N()])
     for (int j = (y_min + 1); j < (y_max + 1 + 2); j++) {
       for (int i = (x_min + 1); i < (x_max + 1 + 2); i++) {
         vel1[i + j * vel1_sizex] = (vel1[i + j * vel1_sizex] * node_mass_pre[i + j * vels_wk_stride] +
@@ -209,7 +229,8 @@ void advec_mom_kernel(bool use_target, int x_min, int x_max, int y_min, int y_ma
       double *node_flux = field.work_array1.data;
       double *mass_flux_y = field.mass_flux_y.data;
 
-#pragma acc parallel loop gang worker vector default(present) collapse(2) clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector collapse(2) clover_use_target(use_target) \
+    present(node_flux[ : field.work_array1.N()], mass_flux_y[ : field.mass_flux_y.N()])
       for (int j = (y_min - 2 + 1); j < (y_max + 2 + 2); j++) {
         for (int i = (x_min + 1); i < (x_max + 1 + 2); i++) {
           node_flux[i + j * vels_wk_stride] =
@@ -225,7 +246,11 @@ void advec_mom_kernel(bool use_target, int x_min, int x_max, int y_min, int y_ma
       double *node_mass_pre = field.work_array3.data;
       double *post_vol = field.work_array6.data;
 
-#pragma acc parallel loop gang worker vector default(present) collapse(2) clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector collapse(2) clover_use_target(use_target)        \
+    present(node_flux[ : field.work_array1.N()], density1[ : field.density1.N()],             \
+            node_mass_post[ : field.work_array2.N()], node_mass_pre[ : field.work_array3.N()],\
+            post_vol[ : field.work_array6.N()])
+            
       for (int j = (y_min - 1 + 1); j < (y_max + 2 + 2); j++) {
         for (int i = (x_min + 1); i < (x_max + 1 + 2); i++) {
           node_mass_post[i + j * vels_wk_stride] =
@@ -249,7 +274,10 @@ void advec_mom_kernel(bool use_target, int x_min, int x_max, int y_min, int y_ma
     double *mom_flux = field.work_array4.data;
     double *celldy = field.celldy.data;
 
-#pragma acc parallel loop gang worker vector default(present) collapse(2) clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector collapse(2) clover_use_target(use_target)   \
+    present(vel1[ : vel1_buffer.N()], node_mass_pre[ : field.work_array3.N()],           \
+            mom_flux[ : field.work_array4.N()], celldy[ : field.celldy.N()],             \
+            node_flux[ : field.work_array1.N()])
     for (int j = (y_min - 1 + 1); j < (y_max + 1 + 2); j++) {
       for (int i = (x_min + 1); i < (x_max + 1 + 2); i++)
         ({
@@ -288,7 +316,9 @@ void advec_mom_kernel(bool use_target, int x_min, int x_max, int y_min, int y_ma
 
     double *node_mass_post = field.work_array2.data;
 
-#pragma acc parallel loop gang worker vector default(present) collapse(2) clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector collapse(2) clover_use_target(use_target)   \
+    present(vel1[ : vel1_buffer.N()], node_mass_pre[ : field.work_array3.N()],           \
+            mom_flux[ : field.work_array4.N()], node_mass_post[ : field.work_array2.N()])
     for (int j = (y_min + 1); j < (y_max + 1 + 2); j++) {
       for (int i = (x_min + 1); i < (x_max + 1 + 2); i++) {
         vel1[i + j * vel1_sizex] = (vel1[i + j * vel1_sizex] * node_mass_pre[i + j * vels_wk_stride] +

--- a/src/acc/build_field.cpp
+++ b/src/acc/build_field.cpp
@@ -1,0 +1,236 @@
+/*
+ Crown Copyright 2012 AWE.
+
+ This file is part of CloverLeaf.
+
+ CloverLeaf is free software: you can redistribute it and/or modify it under
+ the terms of the GNU General Public License as published by the
+ Free Software Foundation, either version 3 of the License, or (at your option)
+ any later version.
+
+ CloverLeaf is distributed in the hope that it will be useful, but
+ WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ details.
+
+ You should have received a copy of the GNU General Public License along with
+ CloverLeaf. If not, see http://www.gnu.org/licenses/.
+ */
+
+// @brief  Allocates the data for each mesh chunk
+// @author Wayne Gaudin
+// @details The data fields for the mesh chunk are allocated based on the mesh
+// size.
+
+#include "build_field.h"
+
+// Allocate device buffers for the data arrays
+void build_field(global_variables &globals) {
+
+  for (int tile = 0; tile < globals.config.tiles_per_chunk; ++tile) {
+
+    tile_type &t = globals.chunk.tiles[tile];
+    field_type &field = t.field;
+
+    double *density0 = field.density0.data;
+    double *density1 = field.density1.data;
+    double *energy0 = field.energy0.data;
+    double *energy1 = field.energy1.data;
+    double *pressure = field.pressure.data;
+    double *viscosity = field.viscosity.data;
+    double *soundspeed = field.soundspeed.data;
+    double *yvel0 = field.yvel0.data;
+    double *yvel1 = field.yvel1.data;
+    double *xvel0 = field.xvel0.data;
+    double *xvel1 = field.xvel1.data;
+    double *vol_flux_x = field.vol_flux_x.data;
+    double *vol_flux_y = field.vol_flux_y.data;
+    double *mass_flux_x = field.mass_flux_x.data;
+    double *mass_flux_y = field.mass_flux_y.data;
+    double *work_array1 = field.work_array1.data;
+    double *work_array2 = field.work_array2.data;
+    double *work_array3 = field.work_array3.data;
+    double *work_array4 = field.work_array4.data;
+    double *work_array5 = field.work_array5.data;
+    double *work_array6 = field.work_array6.data;
+    double *work_array7 = field.work_array7.data;
+    double *cellx = field.cellx.data;
+    double *celldx = field.celldx.data;
+    double *celly = field.celly.data;
+    double *celldy = field.celldy.data;
+    double *vertexx = field.vertexx.data;
+    double *vertexdx = field.vertexdx.data;
+    double *vertexy = field.vertexy.data;
+    double *vertexdy = field.vertexdy.data;
+    double *volume = field.volume.data;
+    double *xarea = field.xarea.data;
+    double *yarea = field.yarea.data;
+
+#pragma omp target enter data map(alloc : density0[ : field.density0.N()]) map(alloc : density1[ : field.density1.N()])                    \
+    map(alloc : energy0[ : field.energy0.N()]) map(alloc : energy1[ : field.energy1.N()]) map(alloc : pressure[ : field.pressure.N()])     \
+    map(alloc : viscosity[ : field.viscosity.N()]) map(alloc : soundspeed[ : field.soundspeed.N()]) map(alloc : yvel0[ : field.yvel0.N()]) \
+    map(alloc : yvel1[ : field.yvel1.N()]) map(alloc : xvel0[ : field.xvel0.N()]) map(alloc : xvel1[ : field.xvel1.N()])                   \
+    map(alloc : vol_flux_x[ : field.vol_flux_x.N()]) map(alloc : vol_flux_y[ : field.vol_flux_y.N()])                                      \
+    map(alloc : mass_flux_x[ : field.mass_flux_x.N()]) map(alloc : mass_flux_y[ : field.mass_flux_y.N()])                                  \
+    map(alloc : work_array1[ : field.work_array1.N()]) map(alloc : work_array2[ : field.work_array2.N()])                                  \
+    map(alloc : work_array3[ : field.work_array3.N()]) map(alloc : work_array4[ : field.work_array4.N()])                                  \
+    map(alloc : work_array5[ : field.work_array5.N()]) map(alloc : work_array6[ : field.work_array6.N()])                                  \
+    map(alloc : work_array7[ : field.work_array7.N()]) map(alloc : cellx[ : field.cellx.N()]) map(alloc : celldx[ : field.celldx.N()])     \
+    map(alloc : celly[ : field.celly.N()]) map(alloc : celldy[ : field.celldy.N()]) map(alloc : vertexx[ : field.vertexx.N()])             \
+    map(alloc : vertexdx[ : field.vertexdx.N()]) map(alloc : vertexy[ : field.vertexy.N()]) map(alloc : vertexdy[ : field.vertexdy.N()])   \
+    map(alloc : volume[ : field.volume.N()]) map(alloc : xarea[ : field.xarea.N()]) map(alloc : yarea[ : field.yarea.N()])
+
+    const int xrange = (t.info.t_xmax + 2) - (t.info.t_xmin - 2) + 1;
+    const int yrange = (t.info.t_ymax + 2) - (t.info.t_ymin - 2) + 1;
+
+    // (t_xmin-2:t_xmax+2, t_ymin-2:t_ymax+2)
+
+    //		t.field.density0 = Buffer2D<double>(range<2>(xrange, yrange));
+    //		t.field.density1 = Buffer2D<double>(range<2>(xrange, yrange));
+    //		t.field.energy0 = Buffer2D<double>(range<2>(xrange, yrange));
+    //		t.field.energy1 = Buffer2D<double>(range<2>(xrange, yrange));
+    //		t.field.pressure = Buffer2D<double>(range<2>(xrange, yrange));
+    //		t.field.viscosity = Buffer2D<double>(range<2>(xrange, yrange));
+    //		t.field.soundspeed = Buffer2D<double>(range<2>(xrange, yrange));
+    //
+    //		// (t_xmin-2:t_xmax+3, t_ymin-2:t_ymax+3)
+    //		t.field.xvel0 = Buffer2D<double>(range<2>(xrange + 1, yrange + 1));
+    //		t.field.xvel1 = Buffer2D<double>(range<2>(xrange + 1, yrange + 1));
+    //		t.field.yvel0 = Buffer2D<double>(range<2>(xrange + 1, yrange + 1));
+    //		t.field.yvel1 = Buffer2D<double>(range<2>(xrange + 1, yrange + 1));
+    //
+    //		// (t_xmin-2:t_xmax+3, t_ymin-2:t_ymax+2)
+    //		t.field.vol_flux_x = Buffer2D<double>(range<2>(xrange + 1, yrange));
+    //		t.field.mass_flux_x = Buffer2D<double>(range<2>(xrange + 1, yrange));
+    //		// (t_xmin-2:t_xmax+2, t_ymin-2:t_ymax+3)
+    //		t.field.vol_flux_y = Buffer2D<double>(range<2>(xrange, yrange + 1));
+    //		t.field.mass_flux_y = Buffer2D<double>(range<2>(xrange, yrange + 1));
+    //
+    //		// (t_xmin-2:t_xmax+3, t_ymin-2:t_ymax+3)
+    //		t.field.work_array1 = Buffer2D<double>(range<2>(xrange + 1, yrange + 1));
+    //		t.field.work_array2 = Buffer2D<double>(range<2>(xrange + 1, yrange + 1));
+    //		t.field.work_array3 = Buffer2D<double>(range<2>(xrange + 1, yrange + 1));
+    //		t.field.work_array4 = Buffer2D<double>(range<2>(xrange + 1, yrange + 1));
+    //		t.field.work_array5 = Buffer2D<double>(range<2>(xrange + 1, yrange + 1));
+    //		t.field.work_array6 = Buffer2D<double>(range<2>(xrange + 1, yrange + 1));
+    //		t.field.work_array7 = Buffer2D<double>(range<2>(xrange + 1, yrange + 1));
+    //
+    //		// (t_xmin-2:t_xmax+2)
+    //		t.field.cellx = Buffer1D<double>(range<1>(xrange));
+    //		t.field.celldx = Buffer1D<double>(range<1>(xrange));
+    //		// (t_ymin-2:t_ymax+2)
+    //		t.field.celly = Buffer1D<double>(range<1>(yrange));
+    //		t.field.celldy = Buffer1D<double>(range<1>(yrange));
+    //		// (t_xmin-2:t_xmax+3)
+    //		t.field.vertexx = Buffer1D<double>(range<1>(xrange + 1));
+    //		t.field.vertexdx = Buffer1D<double>(range<1>(xrange + 1));
+    //		// (t_ymin-2:t_ymax+3)
+    //		t.field.vertexy = Buffer1D<double>(range<1>(yrange + 1));
+    //		t.field.vertexdy = Buffer1D<double>(range<1>(yrange + 1));
+    //
+    //		// (t_xmin-2:t_xmax+2, t_ymin-2:t_ymax+2)
+    //		t.field.volume = Buffer2D<double>(range<2>(xrange, yrange));
+    //		// (t_xmin-2:t_xmax+3, t_ymin-2:t_ymax+2)
+    //		t.field.xarea = Buffer2D<double>(range<2>(xrange + 1, yrange));
+    //		// (t_xmin-2:t_xmax+2, t_ymin-2:t_ymax+3)
+    //		t.field.yarea = Buffer2D<double>(range<2>(xrange, yrange + 1));
+
+    // Zeroing isn't strictly necessary but it ensures physical pages
+    // are allocated. This prevents first touch overheads in the main code
+    // cycle which can skew timings in the first step
+
+    // Take a reference to the lowest structure, as Kokkos device cannot necessarily chase through the structure.
+
+    //		Kokkos::MDRangePolicy <Kokkos::Rank<2>> loop_bounds_1({0, 0}, {xrange + 1, yrange + 1});
+
+    // Nested loop over (t_ymin-2:t_ymax+3) and (t_xmin-2:t_xmax+3) inclusive
+
+    const int vels_wk_stride = field.vels_wk_stride;
+
+#pragma omp target teams distribute parallel for simd collapse(2) clover_use_target(globals.context.use_target)
+    for (int j = 0; j < (yrange + 1); j++) {
+      for (int i = 0; i < (xrange + 1); i++) {
+        work_array1[i + j * vels_wk_stride] = 0.0;
+        work_array2[i + j * vels_wk_stride] = 0.0;
+        work_array3[i + j * vels_wk_stride] = 0.0;
+        work_array4[i + j * vels_wk_stride] = 0.0;
+        work_array5[i + j * vels_wk_stride] = 0.0;
+        work_array6[i + j * vels_wk_stride] = 0.0;
+        work_array7[i + j * vels_wk_stride] = 0.0;
+        xvel0[i + j * vels_wk_stride] = 0.0;
+        xvel1[i + j * vels_wk_stride] = 0.0;
+        yvel0[i + j * vels_wk_stride] = 0.0;
+        yvel1[i + j * vels_wk_stride] = 0.0;
+      }
+    }
+
+    // Nested loop over (t_ymin-2:t_ymax+2) and (t_xmin-2:t_xmax+2) inclusive
+    const int base_stride = field.base_stride;
+
+#pragma omp target teams distribute parallel for simd collapse(2) clover_use_target(globals.context.use_target)
+    for (int j = 0; j < (yrange); j++) {
+      for (int i = 0; i < (xrange); i++) {
+        density0[i + j * base_stride] = 0.0;
+        density1[i + j * base_stride] = 0.0;
+        energy0[i + j * base_stride] = 0.0;
+        energy1[i + j * base_stride] = 0.0;
+        pressure[i + j * base_stride] = 0.0;
+        viscosity[i + j * base_stride] = 0.0;
+        soundspeed[i + j * base_stride] = 0.0;
+        volume[i + j * base_stride] = 0.0;
+      }
+    }
+
+    // Nested loop over (t_ymin-2:t_ymax+2) and (t_xmin-2:t_xmax+3) inclusive
+    const int flux_x_stride = field.flux_x_stride;
+
+#pragma omp target teams distribute parallel for simd collapse(2) clover_use_target(globals.context.use_target)
+    for (int j = 0; j < (yrange); j++) {
+      for (int i = 0; i < (xrange); i++) {
+        vol_flux_x[i + j * flux_x_stride] = 0.0;
+        mass_flux_x[i + j * flux_x_stride] = 0.0;
+        xarea[i + j * flux_x_stride] = 0.0;
+      }
+    }
+
+    // Nested loop over (t_ymin-2:t_ymax+3) and (t_xmin-2:t_xmax+2) inclusive
+    const int flux_y_stride = field.flux_y_stride;
+
+#pragma omp target teams distribute parallel for simd collapse(2) clover_use_target(globals.context.use_target)
+    for (int j = 0; j < (yrange + 1); j++) {
+      for (int i = 0; i < (xrange); i++) {
+        vol_flux_y[i + j * flux_y_stride] = 0.0;
+        mass_flux_y[i + j * flux_y_stride] = 0.0;
+        yarea[i + j * flux_y_stride] = 0.0;
+      }
+    }
+
+// (t_xmin-2:t_xmax+2) inclusive
+#pragma omp target teams distribute parallel for simd clover_use_target(globals.context.use_target)
+    for (int id = 0; id < (xrange); id++) {
+      cellx[id] = 0.0;
+      celldx[id] = 0.0;
+    }
+
+// (t_ymin-2:t_ymax+2) inclusive
+#pragma omp target teams distribute parallel for simd clover_use_target(globals.context.use_target)
+    for (int id = 0; id < (yrange); id++) {
+      celly[id] = 0.0;
+      celldy[id] = 0.0;
+    }
+
+// (t_xmin-2:t_xmax+3) inclusive
+#pragma omp target teams distribute parallel for simd clover_use_target(globals.context.use_target)
+    for (int id = 0; id < (xrange + 1); id++) {
+      vertexx[id] = 0.0;
+      vertexdx[id] = 0.0;
+    }
+
+// (t_ymin-2:t_ymax+3) inclusive
+#pragma omp target teams distribute parallel for simd clover_use_target(globals.context.use_target)
+    for (int id = 0; id < (yrange + 1); id++) {
+      vertexy[id] = 0.0;
+      vertexdy[id] = 0.0;
+    }
+  }
+}

--- a/src/acc/build_field.cpp
+++ b/src/acc/build_field.cpp
@@ -66,19 +66,19 @@ void build_field(global_variables &globals) {
     double *xarea = field.xarea.data;
     double *yarea = field.yarea.data;
 
-#pragma omp target enter data map(alloc : density0[ : field.density0.N()]) map(alloc : density1[ : field.density1.N()])                    \
-    map(alloc : energy0[ : field.energy0.N()]) map(alloc : energy1[ : field.energy1.N()]) map(alloc : pressure[ : field.pressure.N()])     \
-    map(alloc : viscosity[ : field.viscosity.N()]) map(alloc : soundspeed[ : field.soundspeed.N()]) map(alloc : yvel0[ : field.yvel0.N()]) \
-    map(alloc : yvel1[ : field.yvel1.N()]) map(alloc : xvel0[ : field.xvel0.N()]) map(alloc : xvel1[ : field.xvel1.N()])                   \
-    map(alloc : vol_flux_x[ : field.vol_flux_x.N()]) map(alloc : vol_flux_y[ : field.vol_flux_y.N()])                                      \
-    map(alloc : mass_flux_x[ : field.mass_flux_x.N()]) map(alloc : mass_flux_y[ : field.mass_flux_y.N()])                                  \
-    map(alloc : work_array1[ : field.work_array1.N()]) map(alloc : work_array2[ : field.work_array2.N()])                                  \
-    map(alloc : work_array3[ : field.work_array3.N()]) map(alloc : work_array4[ : field.work_array4.N()])                                  \
-    map(alloc : work_array5[ : field.work_array5.N()]) map(alloc : work_array6[ : field.work_array6.N()])                                  \
-    map(alloc : work_array7[ : field.work_array7.N()]) map(alloc : cellx[ : field.cellx.N()]) map(alloc : celldx[ : field.celldx.N()])     \
-    map(alloc : celly[ : field.celly.N()]) map(alloc : celldy[ : field.celldy.N()]) map(alloc : vertexx[ : field.vertexx.N()])             \
-    map(alloc : vertexdx[ : field.vertexdx.N()]) map(alloc : vertexy[ : field.vertexy.N()]) map(alloc : vertexdy[ : field.vertexdy.N()])   \
-    map(alloc : volume[ : field.volume.N()]) map(alloc : xarea[ : field.xarea.N()]) map(alloc : yarea[ : field.yarea.N()])
+#pragma acc enter data create(density0[ : field.density0.N()]) create(density1[ : field.density1.N()])                    \
+    create(energy0[ : field.energy0.N()]) create(energy1[ : field.energy1.N()]) create(pressure[ : field.pressure.N()])     \
+    create(viscosity[ : field.viscosity.N()]) create(soundspeed[ : field.soundspeed.N()]) create(yvel0[ : field.yvel0.N()]) \
+    create(yvel1[ : field.yvel1.N()]) create(xvel0[ : field.xvel0.N()]) create(xvel1[ : field.xvel1.N()])                   \
+    create(vol_flux_x[ : field.vol_flux_x.N()]) create(vol_flux_y[ : field.vol_flux_y.N()])                                      \
+    create(mass_flux_x[ : field.mass_flux_x.N()]) create(mass_flux_y[ : field.mass_flux_y.N()])                                  \
+    create(work_array1[ : field.work_array1.N()]) create(work_array2[ : field.work_array2.N()])                                  \
+    create(work_array3[ : field.work_array3.N()]) create(work_array4[ : field.work_array4.N()])                                  \
+    create(work_array5[ : field.work_array5.N()]) create(work_array6[ : field.work_array6.N()])                                  \
+    create(work_array7[ : field.work_array7.N()]) create(cellx[ : field.cellx.N()]) create(celldx[ : field.celldx.N()])     \
+    create(celly[ : field.celly.N()]) create(celldy[ : field.celldy.N()]) create(vertexx[ : field.vertexx.N()])             \
+    create(vertexdx[ : field.vertexdx.N()]) create(vertexy[ : field.vertexy.N()]) create(vertexdy[ : field.vertexdy.N()])   \
+    create(volume[ : field.volume.N()]) create(xarea[ : field.xarea.N()]) create(yarea[ : field.yarea.N()])
 
     const int xrange = (t.info.t_xmax + 2) - (t.info.t_xmin - 2) + 1;
     const int yrange = (t.info.t_ymax + 2) - (t.info.t_ymin - 2) + 1;
@@ -147,7 +147,7 @@ void build_field(global_variables &globals) {
 
     const int vels_wk_stride = field.vels_wk_stride;
 
-#pragma omp target teams distribute parallel for simd collapse(2) clover_use_target(globals.context.use_target)
+#pragma acc parallel loop gang worker vector default(present) collapse(2) clover_use_target(globals.context.use_target)
     for (int j = 0; j < (yrange + 1); j++) {
       for (int i = 0; i < (xrange + 1); i++) {
         work_array1[i + j * vels_wk_stride] = 0.0;
@@ -167,7 +167,7 @@ void build_field(global_variables &globals) {
     // Nested loop over (t_ymin-2:t_ymax+2) and (t_xmin-2:t_xmax+2) inclusive
     const int base_stride = field.base_stride;
 
-#pragma omp target teams distribute parallel for simd collapse(2) clover_use_target(globals.context.use_target)
+#pragma acc parallel loop gang worker vector default(present) collapse(2) clover_use_target(globals.context.use_target)
     for (int j = 0; j < (yrange); j++) {
       for (int i = 0; i < (xrange); i++) {
         density0[i + j * base_stride] = 0.0;
@@ -184,7 +184,7 @@ void build_field(global_variables &globals) {
     // Nested loop over (t_ymin-2:t_ymax+2) and (t_xmin-2:t_xmax+3) inclusive
     const int flux_x_stride = field.flux_x_stride;
 
-#pragma omp target teams distribute parallel for simd collapse(2) clover_use_target(globals.context.use_target)
+#pragma acc parallel loop gang worker vector default(present) collapse(2) clover_use_target(globals.context.use_target)
     for (int j = 0; j < (yrange); j++) {
       for (int i = 0; i < (xrange); i++) {
         vol_flux_x[i + j * flux_x_stride] = 0.0;
@@ -196,7 +196,7 @@ void build_field(global_variables &globals) {
     // Nested loop over (t_ymin-2:t_ymax+3) and (t_xmin-2:t_xmax+2) inclusive
     const int flux_y_stride = field.flux_y_stride;
 
-#pragma omp target teams distribute parallel for simd collapse(2) clover_use_target(globals.context.use_target)
+#pragma acc parallel loop gang worker vector default(present) collapse(2) clover_use_target(globals.context.use_target)
     for (int j = 0; j < (yrange + 1); j++) {
       for (int i = 0; i < (xrange); i++) {
         vol_flux_y[i + j * flux_y_stride] = 0.0;
@@ -206,28 +206,28 @@ void build_field(global_variables &globals) {
     }
 
 // (t_xmin-2:t_xmax+2) inclusive
-#pragma omp target teams distribute parallel for simd clover_use_target(globals.context.use_target)
+#pragma acc parallel loop gang worker vector default(present) clover_use_target(globals.context.use_target)
     for (int id = 0; id < (xrange); id++) {
       cellx[id] = 0.0;
       celldx[id] = 0.0;
     }
 
 // (t_ymin-2:t_ymax+2) inclusive
-#pragma omp target teams distribute parallel for simd clover_use_target(globals.context.use_target)
+#pragma acc parallel loop gang worker vector default(present) clover_use_target(globals.context.use_target)
     for (int id = 0; id < (yrange); id++) {
       celly[id] = 0.0;
       celldy[id] = 0.0;
     }
 
 // (t_xmin-2:t_xmax+3) inclusive
-#pragma omp target teams distribute parallel for simd clover_use_target(globals.context.use_target)
+#pragma acc parallel loop gang worker vector default(present) clover_use_target(globals.context.use_target)
     for (int id = 0; id < (xrange + 1); id++) {
       vertexx[id] = 0.0;
       vertexdx[id] = 0.0;
     }
 
 // (t_ymin-2:t_ymax+3) inclusive
-#pragma omp target teams distribute parallel for simd clover_use_target(globals.context.use_target)
+#pragma acc parallel loop gang worker vector default(present) clover_use_target(globals.context.use_target)
     for (int id = 0; id < (yrange + 1); id++) {
       vertexy[id] = 0.0;
       vertexdy[id] = 0.0;

--- a/src/acc/build_field.cpp
+++ b/src/acc/build_field.cpp
@@ -147,7 +147,12 @@ void build_field(global_variables &globals) {
 
     const int vels_wk_stride = field.vels_wk_stride;
 
-#pragma acc parallel loop gang worker vector default(present) collapse(2) clover_use_target(globals.context.use_target)
+#pragma acc parallel loop gang worker vector collapse(2) clover_use_target(globals.context.use_target) \
+    present(work_array1[ : field.work_array1.N()], work_array2[ : field.work_array2.N()],              \
+            work_array3[ : field.work_array3.N()], work_array4[ : field.work_array4.N()],              \
+            work_array5[ : field.work_array5.N()], work_array6[ : field.work_array6.N()],              \
+            work_array7[ : field.work_array7.N()], xvel0[ : field.xvel0.N()],                          \
+            xvel1[ : field.xvel1.N()], yvel0[ : field.yvel0.N()], yvel1[ : field.yvel1.N()])
     for (int j = 0; j < (yrange + 1); j++) {
       for (int i = 0; i < (xrange + 1); i++) {
         work_array1[i + j * vels_wk_stride] = 0.0;
@@ -167,7 +172,11 @@ void build_field(global_variables &globals) {
     // Nested loop over (t_ymin-2:t_ymax+2) and (t_xmin-2:t_xmax+2) inclusive
     const int base_stride = field.base_stride;
 
-#pragma acc parallel loop gang worker vector default(present) collapse(2) clover_use_target(globals.context.use_target)
+#pragma acc parallel loop gang worker vector collapse(2) clover_use_target(globals.context.use_target) \
+    present(density0[ : field.density0.N()], density1[ : field.density1.N()],                          \
+            energy0[ : field.energy0.N()], energy1[ : field.energy1.N()],                              \
+            viscosity[ : field.viscosity.N()], soundspeed[ : field.soundspeed.N()],                    \
+            volume[ : field.volume.N()], pressure[ : field.pressure.N()])
     for (int j = 0; j < (yrange); j++) {
       for (int i = 0; i < (xrange); i++) {
         density0[i + j * base_stride] = 0.0;
@@ -184,7 +193,9 @@ void build_field(global_variables &globals) {
     // Nested loop over (t_ymin-2:t_ymax+2) and (t_xmin-2:t_xmax+3) inclusive
     const int flux_x_stride = field.flux_x_stride;
 
-#pragma acc parallel loop gang worker vector default(present) collapse(2) clover_use_target(globals.context.use_target)
+#pragma acc parallel loop gang worker vector collapse(2) clover_use_target(globals.context.use_target) \
+    present(vol_flux_x[ : field.vol_flux_x.N()], mass_flux_x[ : field.mass_flux_x.N()],                  \
+            xarea[ : field.xarea.N()])
     for (int j = 0; j < (yrange); j++) {
       for (int i = 0; i < (xrange); i++) {
         vol_flux_x[i + j * flux_x_stride] = 0.0;
@@ -196,7 +207,9 @@ void build_field(global_variables &globals) {
     // Nested loop over (t_ymin-2:t_ymax+3) and (t_xmin-2:t_xmax+2) inclusive
     const int flux_y_stride = field.flux_y_stride;
 
-#pragma acc parallel loop gang worker vector default(present) collapse(2) clover_use_target(globals.context.use_target)
+#pragma acc parallel loop gang worker vector collapse(2) clover_use_target(globals.context.use_target) \
+    present(vol_flux_y[ : field.vol_flux_y.N()], mass_flux_y[ : field.mass_flux_y.N()],                  \
+            yarea[ : field.yarea.N()])
     for (int j = 0; j < (yrange + 1); j++) {
       for (int i = 0; i < (xrange); i++) {
         vol_flux_y[i + j * flux_y_stride] = 0.0;
@@ -206,28 +219,32 @@ void build_field(global_variables &globals) {
     }
 
 // (t_xmin-2:t_xmax+2) inclusive
-#pragma acc parallel loop gang worker vector default(present) clover_use_target(globals.context.use_target)
+#pragma acc parallel loop gang worker vector clover_use_target(globals.context.use_target) \
+    present(cellx[ : field.cellx.N()], celldx[ : field.celldx.N()])
     for (int id = 0; id < (xrange); id++) {
       cellx[id] = 0.0;
       celldx[id] = 0.0;
     }
 
 // (t_ymin-2:t_ymax+2) inclusive
-#pragma acc parallel loop gang worker vector default(present) clover_use_target(globals.context.use_target)
+#pragma acc parallel loop gang worker vector clover_use_target(globals.context.use_target) \
+    present(celly[ : field.celly.N()], celldy[ : field.celldy.N()])
     for (int id = 0; id < (yrange); id++) {
       celly[id] = 0.0;
       celldy[id] = 0.0;
     }
 
 // (t_xmin-2:t_xmax+3) inclusive
-#pragma acc parallel loop gang worker vector default(present) clover_use_target(globals.context.use_target)
+#pragma acc parallel loop gang worker vector clover_use_target(globals.context.use_target) \
+    present(vertexx[ : field.vertexx.N()], vertexdx[ : field.vertexdx.N()])
     for (int id = 0; id < (xrange + 1); id++) {
       vertexx[id] = 0.0;
       vertexdx[id] = 0.0;
     }
 
 // (t_ymin-2:t_ymax+3) inclusive
-#pragma acc parallel loop gang worker vector default(present) clover_use_target(globals.context.use_target)
+#pragma acc parallel loop gang worker vector clover_use_target(globals.context.use_target) \
+    present(vertexy[ : field.vertexy.N()], vertexdy[ : field.vertexdy.N()])
     for (int id = 0; id < (yrange + 1); id++) {
       vertexy[id] = 0.0;
       vertexdy[id] = 0.0;

--- a/src/acc/calc_dt.cpp
+++ b/src/acc/calc_dt.cpp
@@ -1,0 +1,157 @@
+/*
+ Crown Copyright 2012 AWE.
+
+ This file is part of CloverLeaf.
+
+ CloverLeaf is free software: you can redistribute it and/or modify it under
+ the terms of the GNU General Public License as published by the
+ Free Software Foundation, either version 3 of the License, or (at your option)
+ any later version.
+
+ CloverLeaf is distributed in the hope that it will be useful, but
+ WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ details.
+
+ You should have received a copy of the GNU General Public License along with
+ CloverLeaf. If not, see http://www.gnu.org/licenses/.
+ */
+
+#include "calc_dt.h"
+#include <string>
+
+#include <cmath>
+
+//  @brief Fortran timestep kernel
+//  @author Wayne Gaudin
+//  @details Calculates the minimum timestep on the mesh chunk based on the CFL
+//  condition, the velocity gradient and the velocity divergence. A safety
+//  factor is used to ensure numerical stability.
+
+void calc_dt_kernel(bool use_target, int x_min, int x_max, int y_min, int y_max, double dtmin, double dtc_safe, double dtu_safe,
+                    double dtv_safe, double dtdiv_safe, field_type &field, double &dt_min_val, int &dtl_control, double &xl_pos,
+                    double &yl_pos, int &jldt, int &kldt, int &small) {
+
+  small = 0;
+  dt_min_val = g_big;
+  double jk_control = 1.1;
+
+  // DO k=y_min,y_max
+  //   DO j=x_min,x_max
+  //	Kokkos::MDRangePolicy <Kokkos::Rank<2>> policy({x_min + 1, y_min + 1}, {x_max + 2, y_max + 2});
+
+  const int flux_x_stride = field.flux_x_stride;
+  const int flux_y_stride = field.flux_y_stride;
+
+  const int base_stride = field.base_stride;
+  const int vels_wk_stride = field.vels_wk_stride;
+
+  double *xarea = field.xarea.data;
+  double *yarea = field.yarea.data;
+  double *celldx = field.celldx.data;
+  double *celldy = field.celldy.data;
+  double *volume = field.volume.data;
+  double *density0 = field.density0.data;
+  double *viscosity = field.viscosity.data;
+  double *soundspeed = field.soundspeed.data;
+  double *xvel0 = field.xvel0.data;
+  double *yvel0 = field.yvel0.data;
+
+  // XXX See https://forums.developer.nvidia.com/t/nvc-f-0000-internal-compiler-error-unhandled-size-for-preparing-max-constant/221740
+  double dt_min_val0 = dt_min_val;
+#pragma omp target teams distribute parallel for simd collapse(2) clover_use_target(use_target) map(tofrom : dt_min_val)                   \
+    reduction(min : dt_min_val0)
+  for (int j = (y_min + 1); j < (y_max + 2); j++) {
+    for (int i = (x_min + 1); i < (x_max + 2); i++) {
+      double dsx = celldx[i];
+      double dsy = celldy[j];
+      double cc = soundspeed[i + j * base_stride] * soundspeed[i + j * base_stride];
+      cc = cc + 2.0 * viscosity[i + j * base_stride] / density0[i + j * base_stride];
+      cc = fmax(sqrt(cc), g_small);
+      double dtct = dtc_safe * fmin(dsx, dsy) / cc;
+      double div = 0.0;
+      double dv1 = (xvel0[i + j * vels_wk_stride] + xvel0[(i + 0) + (j + 1) * vels_wk_stride]) * xarea[i + j * flux_x_stride];
+      double dv2 = (xvel0[(i + 1) + (j + 0) * vels_wk_stride] + xvel0[(i + 1) + (j + 1) * vels_wk_stride]) *
+                   xarea[(i + 1) + (j + 0) * flux_x_stride];
+      div = div + dv2 - dv1;
+      double dtut = dtu_safe * 2.0 * volume[i + j * base_stride] / fmax(fmax(fabs(dv1), fabs(dv2)), g_small * volume[i + j * base_stride]);
+      dv1 = (yvel0[i + j * vels_wk_stride] + yvel0[(i + 1) + (j + 0) * vels_wk_stride]) * yarea[i + j * flux_y_stride];
+      dv2 = (yvel0[(i + 0) + (j + 1) * vels_wk_stride] + yvel0[(i + 1) + (j + 1) * vels_wk_stride]) *
+            yarea[(i + 0) + (j + 1) * flux_y_stride];
+      div = div + dv2 - dv1;
+      double dtvt = dtv_safe * 2.0 * volume[i + j * base_stride] / fmax(fmax(fabs(dv1), fabs(dv2)), g_small * volume[i + j * base_stride]);
+      div = div / (2.0 * volume[i + j * base_stride]);
+      double dtdivt;
+      if (div < -g_small) {
+        dtdivt = dtdiv_safe * (-1.0 / div);
+      } else {
+        dtdivt = g_big;
+      }
+      double mins = fmin(dtct, fmin(dtut, fmin(dtvt, fmin(dtdivt, g_big))));
+      dt_min_val0 = fmin(mins, dt_min_val0);
+    }
+  }
+  dt_min_val = dt_min_val0;
+
+  dtl_control = static_cast<int>(10.01 * (jk_control - static_cast<int>(jk_control)));
+  jk_control = jk_control - (jk_control - (int)(jk_control));
+  jldt = ((int)jk_control) % x_max;
+  kldt = static_cast<int>(1.f + (jk_control / x_max));
+
+  if (dt_min_val < dtmin) small = 1;
+
+  if (small != 0) {
+
+    auto &cellx_acc = field.cellx;
+    auto &celly_acc = field.celly;
+    auto &density0_acc = field.density0;
+    auto &energy0_acc = field.energy0;
+    auto &pressure_acc = field.pressure;
+    auto &soundspeed_acc = field.soundspeed;
+    auto &xvel0_acc = field.xvel0;
+    auto &yvel0_acc = field.yvel0;
+
+    std::cout << "Timestep information:" << std::endl
+              << "j, k                 : " << jldt << " " << kldt << std::endl
+              << "x, y                 : " << cellx_acc[jldt] << " " << celly_acc[kldt] << std::endl
+              << "timestep : " << dt_min_val << std::endl
+              << "Cell velocities;" << std::endl
+              << xvel0_acc(jldt, kldt) << " " << yvel0_acc(jldt, kldt) << std::endl
+              << xvel0_acc(jldt + 1, kldt) << " " << yvel0_acc(jldt + 1, kldt) << std::endl
+              << xvel0_acc(jldt + 1, kldt + 1) << " " << yvel0_acc(jldt + 1, kldt + 1) << std::endl
+              << xvel0_acc(jldt, kldt + 1) << " " << yvel0_acc(jldt, kldt + 1) << std::endl
+              << "density, energy, pressure, soundspeed " << std::endl
+              << density0_acc(jldt, kldt) << " " << energy0_acc(jldt, kldt) << " " << pressure_acc(jldt, kldt) << " "
+              << soundspeed_acc(jldt, kldt) << std::endl;
+  }
+}
+
+//  @brief Driver for the timestep kernels
+//  @author Wayne Gaudin
+//  @details Invokes the user specified timestep kernel.
+void calc_dt(global_variables &globals, int tile, double &local_dt, std::string &local_control, double &xl_pos, double &yl_pos, int &jldt,
+             int &kldt) {
+
+  local_dt = g_big;
+
+  int l_control;
+  int small = 0;
+
+#if SYNC_BUFFERS
+  globals.hostToDevice();
+#endif
+
+  tile_type &t = globals.chunk.tiles[tile];
+  calc_dt_kernel(globals.context.use_target, t.info.t_xmin, t.info.t_xmax, t.info.t_ymin, t.info.t_ymax, globals.config.dtmin,
+                 globals.config.dtc_safe, globals.config.dtu_safe, globals.config.dtv_safe, globals.config.dtdiv_safe, t.field, local_dt,
+                 l_control, xl_pos, yl_pos, jldt, kldt, small);
+
+#if SYNC_BUFFERS
+  globals.deviceToHost();
+#endif
+
+  if (l_control == 1) local_control = "sound";
+  if (l_control == 2) local_control = "xvel";
+  if (l_control == 3) local_control = "yvel";
+  if (l_control == 4) local_control = "div";
+}

--- a/src/acc/calc_dt.cpp
+++ b/src/acc/calc_dt.cpp
@@ -57,9 +57,8 @@ void calc_dt_kernel(bool use_target, int x_min, int x_max, int y_min, int y_max,
   double *xvel0 = field.xvel0.data;
   double *yvel0 = field.yvel0.data;
 
-  double dt_min_val0 = dt_min_val;
 #pragma acc parallel loop gang worker vector collapse(2) clover_use_target(use_target) \
-    copy(dt_min_val) reduction(min : dt_min_val0)                                      \
+    reduction(min : dt_min_val)                                                        \
     present(xarea[ : field.xarea.N()], yarea[ : field.yarea.N()],                      \
             celldx[ : field.celldx.N()], celldy[ : field.celldy.N()],                  \
             volume[ : field.volume.N()], density0[ : field.density0.N()],              \

--- a/src/acc/calc_dt.cpp
+++ b/src/acc/calc_dt.cpp
@@ -57,8 +57,14 @@ void calc_dt_kernel(bool use_target, int x_min, int x_max, int y_min, int y_max,
   double *xvel0 = field.xvel0.data;
   double *yvel0 = field.yvel0.data;
 
-#pragma acc parallel loop gang worker vector collapse(2) default(present) clover_use_target(use_target) copy(dt_min_val)                   \
-    reduction(min : dt_min_val)
+  double dt_min_val0 = dt_min_val;
+#pragma acc parallel loop gang worker vector collapse(2) clover_use_target(use_target) \
+    copy(dt_min_val) reduction(min : dt_min_val0)                                      \
+    present(xarea[ : field.xarea.N()], yarea[ : field.yarea.N()],                      \
+            celldx[ : field.celldx.N()], celldy[ : field.celldy.N()],                  \
+            volume[ : field.volume.N()], density0[ : field.density0.N()],              \
+            viscosity[ : field.viscosity.N()], soundspeed[ : field.soundspeed.N()],    \
+            xvel0[ : field.xvel0.N()], yvel0[: field.yvel0.N()])
   for (int j = (y_min + 1); j < (y_max + 2); j++) {
     for (int i = (x_min + 1); i < (x_max + 2); i++) {
       double dsx = celldx[i];

--- a/src/acc/calc_dt.cpp
+++ b/src/acc/calc_dt.cpp
@@ -57,8 +57,9 @@ void calc_dt_kernel(bool use_target, int x_min, int x_max, int y_min, int y_max,
   double *xvel0 = field.xvel0.data;
   double *yvel0 = field.yvel0.data;
 
+  double dt_min_val0 = dt_min_val;
 #pragma acc parallel loop gang worker vector collapse(2) clover_use_target(use_target) \
-    reduction(min : dt_min_val)                                                        \
+    reduction(min : dt_min_val0)                                                       \
     present(xarea[ : field.xarea.N()], yarea[ : field.yarea.N()],                      \
             celldx[ : field.celldx.N()], celldy[ : field.celldy.N()],                  \
             volume[ : field.volume.N()], density0[ : field.density0.N()],              \
@@ -91,9 +92,11 @@ void calc_dt_kernel(bool use_target, int x_min, int x_max, int y_min, int y_max,
         dtdivt = g_big;
       }
       double mins = fmin(dtct, fmin(dtut, fmin(dtvt, fmin(dtdivt, g_big))));
-      dt_min_val = fmin(mins, dt_min_val);
+      dt_min_val0 = fmin(mins, dt_min_val0);
     }
   }
+
+  dt_min_val = dt_min_val0;
 
   dtl_control = static_cast<int>(10.01 * (jk_control - static_cast<int>(jk_control)));
   jk_control = jk_control - (jk_control - (int)(jk_control));

--- a/src/acc/calc_dt.cpp
+++ b/src/acc/calc_dt.cpp
@@ -57,10 +57,10 @@ void calc_dt_kernel(bool use_target, int x_min, int x_max, int y_min, int y_max,
   double *xvel0 = field.xvel0.data;
   double *yvel0 = field.yvel0.data;
 
-  // XXX See https://forums.developer.nvidia.com/t/nvc-f-0000-internal-compiler-error-unhandled-size-for-preparing-max-constant/221740
-  double dt_min_val0 = dt_min_val;
-#pragma omp target teams distribute parallel for simd collapse(2) clover_use_target(use_target) map(tofrom : dt_min_val)                   \
-    reduction(min : dt_min_val0)
+/* TODO I think this loop has room for speedup? Instead of doing 1 do 5 min reductions? */
+
+#pragma acc parallel loop gang worker vector collapse(2) default(present) clover_use_target(use_target) copy(dt_min_val)                   \
+    reduction(min : dt_min_val)
   for (int j = (y_min + 1); j < (y_max + 2); j++) {
     for (int i = (x_min + 1); i < (x_max + 2); i++) {
       double dsx = celldx[i];
@@ -88,10 +88,9 @@ void calc_dt_kernel(bool use_target, int x_min, int x_max, int y_min, int y_max,
         dtdivt = g_big;
       }
       double mins = fmin(dtct, fmin(dtut, fmin(dtvt, fmin(dtdivt, g_big))));
-      dt_min_val0 = fmin(mins, dt_min_val0);
+      dt_min_val = fmin(mins, dt_min_val);
     }
   }
-  dt_min_val = dt_min_val0;
 
   dtl_control = static_cast<int>(10.01 * (jk_control - static_cast<int>(jk_control)));
   jk_control = jk_control - (jk_control - (int)(jk_control));

--- a/src/acc/calc_dt.cpp
+++ b/src/acc/calc_dt.cpp
@@ -57,8 +57,6 @@ void calc_dt_kernel(bool use_target, int x_min, int x_max, int y_min, int y_max,
   double *xvel0 = field.xvel0.data;
   double *yvel0 = field.yvel0.data;
 
-/* TODO I think this loop has room for speedup? Instead of doing 1 do 5 min reductions? */
-
 #pragma acc parallel loop gang worker vector collapse(2) default(present) clover_use_target(use_target) copy(dt_min_val)                   \
     reduction(min : dt_min_val)
   for (int j = (y_min + 1); j < (y_max + 2); j++) {

--- a/src/acc/comms_kernel.cpp
+++ b/src/acc/comms_kernel.cpp
@@ -1,0 +1,265 @@
+/*
+ Crown Copyright 2012 AWE.
+
+ This file is part of CloverLeaf.
+
+ CloverLeaf is free software: you can redistribute it and/or modify it under
+ the terms of the GNU General Public License as published by the
+ Free Software Foundation, either version 3 of the License, or (at your option)
+ any later version.
+
+ CloverLeaf is distributed in the hope that it will be useful, but
+ WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ details.
+
+ You should have received a copy of the GNU General Public License along with
+ CloverLeaf. If not, see http://www.gnu.org/licenses/.
+ */
+
+//  @brief Communication Utilities
+//  @author Wayne Gaudin
+//  @details Contains all utilities required to run CloverLeaf in a distributed
+//  environment, including initialisation, mesh decompostion, reductions and
+//  halo exchange using explicit buffers.
+//
+//  Note the halo exchange is currently coded as simply as possible and no
+//  optimisations have been implemented, such as post receives before sends or packing
+//  buffers with multiple data fields. This is intentional so the effect of these
+//  optimisations can be measured on large systems, as and when they are added.
+//
+//  Even without these modifications CloverLeaf weak scales well on moderately sized
+//  systems of the order of 10K cores.
+
+#include "comms_kernel.h"
+#include "comms.h"
+#include "pack_kernel.h"
+
+void clover_allocate_buffers(global_variables &globals, parallel_ &parallel) {
+
+  // Unallocated buffers for external boundaries caused issues on some systems so they are now
+  //  all allocated
+  if (parallel.task == globals.chunk.task) {
+
+    //		new(&globals.chunk.left_snd)   Kokkos::View<double *>("left_snd", 10 * 2 * (globals.chunk.y_max +	5));
+    //		new(&globals.chunk.left_rcv)   Kokkos::View<double *>("left_rcv", 10 * 2 * (globals.chunk.y_max +	5));
+    //		new(&globals.chunk.right_snd)  Kokkos::View<double *>("right_snd", 10 * 2 * (globals.chunk.y_max +	5));
+    //		new(&globals.chunk.right_rcv)  Kokkos::View<double *>("right_rcv", 10 * 2 * (globals.chunk.y_max +	5));
+    //		new(&globals.chunk.bottom_snd) Kokkos::View<double *>("bottom_snd", 10 * 2 * (globals.chunk.x_max +	5));
+    //		new(&globals.chunk.bottom_rcv) Kokkos::View<double *>("bottom_rcv", 10 * 2 * (globals.chunk.x_max +	5));
+    //		new(&globals.chunk.top_snd)    Kokkos::View<double *>("top_snd", 10 * 2 * (globals.chunk.x_max +	5));
+    //		new(&globals.chunk.top_rcv)    Kokkos::View<double *>("top_rcv", 10 * 2 * (globals.chunk.x_max +	5));
+    //
+    //		// Create host mirrors of device buffers. This makes this, and deep_copy, a no-op if the View is in host memory already.
+    //		globals.chunk.hm_left_snd = Kokkos::create_mirror_view(
+    //				globals.chunk.left_snd);
+    //		globals.chunk.hm_left_rcv = Kokkos::create_mirror_view(
+    //				globals.chunk.left_rcv);
+    //		globals.chunk.hm_right_snd = Kokkos::create_mirror_view(
+    //				globals.chunk.right_snd);
+    //		globals.chunk.hm_right_rcv = Kokkos::create_mirror_view(
+    //				globals.chunk.right_rcv);
+    //		globals.chunk.hm_bottom_snd = Kokkos::create_mirror_view(
+    //				globals.chunk.bottom_snd);
+    //		globals.chunk.hm_bottom_rcv = Kokkos::create_mirror_view(
+    //				globals.chunk.bottom_rcv);
+    //		globals.chunk.hm_top_snd = Kokkos::create_mirror_view(globals.chunk.top_snd);
+    //		globals.chunk.hm_top_rcv = Kokkos::create_mirror_view(globals.chunk.top_rcv);
+  }
+}
+
+void clover_exchange(global_variables &globals, const int fields[NUM_FIELDS], const int depth) {
+
+  // Assuming 1 patch per task, this will be changed
+
+  int left_right_offset[NUM_FIELDS];
+  int bottom_top_offset[NUM_FIELDS];
+
+  MPI_Request request[4] = {0};
+  int message_count = 0;
+
+  int end_pack_index_left_right = 0;
+  int end_pack_index_bottom_top = 0;
+  for (int field = 0; field < NUM_FIELDS; ++field) {
+    if (fields[field] == 1) {
+      left_right_offset[field] = end_pack_index_left_right;
+      bottom_top_offset[field] = end_pack_index_bottom_top;
+      end_pack_index_left_right += depth * (globals.chunk.y_max + 5);
+      end_pack_index_bottom_top += depth * (globals.chunk.x_max + 5);
+    }
+  }
+
+  static clover::Buffer1D<double> left_rcv_buffer(globals.context, end_pack_index_left_right);
+  static clover::Buffer1D<double> left_snd_buffer(globals.context, end_pack_index_left_right);
+  static clover::Buffer1D<double> right_rcv_buffer(globals.context, end_pack_index_left_right);
+  static clover::Buffer1D<double> right_snd_buffer(globals.context, end_pack_index_left_right);
+
+  static clover::Buffer1D<double> top_rcv_buffer(globals.context, end_pack_index_bottom_top);
+  static clover::Buffer1D<double> top_snd_buffer(globals.context, end_pack_index_bottom_top);
+  static clover::Buffer1D<double> bottom_rcv_buffer(globals.context, end_pack_index_bottom_top);
+  static clover::Buffer1D<double> bottom_snd_buffer(globals.context, end_pack_index_bottom_top);
+
+  double *left_rcv = left_rcv_buffer.data;
+  double *left_snd = left_snd_buffer.data;
+  double *right_rcv = right_rcv_buffer.data;
+  double *right_snd = right_snd_buffer.data;
+  double *top_rcv = top_rcv_buffer.data;
+  double *top_snd = top_snd_buffer.data;
+  double *bottom_rcv = bottom_rcv_buffer.data;
+  double *bottom_snd = bottom_snd_buffer.data;
+
+  bool stage = globals.config.staging_buffer;
+
+#pragma omp target enter data map(alloc : left_rcv[ : left_rcv_buffer.N()]) map(alloc : left_snd[ : left_snd_buffer.N()])                  \
+    map(alloc : right_rcv[ : right_rcv_buffer.N()]) map(alloc : right_snd[ : right_snd_buffer.N()])                                        \
+    map(alloc : top_rcv[ : top_rcv_buffer.N()]) map(alloc : top_snd[ : top_snd_buffer.N()])                                                \
+    map(alloc : bottom_rcv[ : bottom_rcv_buffer.N()]) map(alloc : bottom_snd[ : bottom_snd_buffer.N()])
+
+  if (globals.chunk.chunk_neighbours[chunk_left] != external_face) {
+    // do left exchanges
+    // Find left hand tiles
+    for (int tile = 0; tile < globals.config.tiles_per_chunk; ++tile) {
+      if (globals.chunk.tiles[tile].info.external_tile_mask[tile_left] == 1) {
+        clover_pack_left(globals, left_snd_buffer, tile, fields, depth, left_right_offset);
+      }
+    }
+
+    // send and recv messages to the left
+#pragma omp target update if (stage) from(left_snd[ : left_snd_buffer.N()])
+#pragma omp target data if (!stage) use_device_ptr(left_snd, left_rcv)
+    clover_send_recv_message_left(globals, left_snd, left_rcv, end_pack_index_left_right, 1, 2, request[message_count],
+                                  request[message_count + 1]);
+    message_count += 2;
+  }
+
+  if (globals.chunk.chunk_neighbours[chunk_right] != external_face) {
+    // do right exchanges
+    for (int tile = 0; tile < globals.config.tiles_per_chunk; ++tile) {
+      if (globals.chunk.tiles[tile].info.external_tile_mask[tile_right] == 1) {
+        clover_pack_right(globals, right_snd_buffer, tile, fields, depth, left_right_offset);
+      }
+    }
+
+    // send message to the right
+#pragma omp target update if (stage) from(right_snd[ : right_snd_buffer.N()])
+#pragma omp target data if (!stage) use_device_ptr(right_snd, right_rcv)
+    clover_send_recv_message_right(globals, right_snd, right_rcv, end_pack_index_left_right, 2, 1, request[message_count],
+                                   request[message_count + 1]);
+    message_count += 2;
+  }
+
+  // make a call to wait / sync
+  MPI_Waitall(message_count, request, MPI_STATUS_IGNORE);
+
+  // Copy back to the device
+
+  // unpack in left direction
+  if (globals.chunk.chunk_neighbours[chunk_left] != external_face) {
+#pragma omp target update if (stage) to(left_rcv[ : left_rcv_buffer.N()])
+    for (int tile = 0; tile < globals.config.tiles_per_chunk; ++tile) {
+      if (globals.chunk.tiles[tile].info.external_tile_mask[tile_left] == 1) {
+        clover_unpack_left(globals, left_rcv_buffer, fields, tile, depth, left_right_offset);
+      }
+    }
+  }
+
+  // unpack in right direction
+  if (globals.chunk.chunk_neighbours[chunk_right] != external_face) {
+#pragma omp target update if (stage) to(right_rcv[ : right_rcv_buffer.N()])
+    for (int tile = 0; tile < globals.config.tiles_per_chunk; ++tile) {
+      if (globals.chunk.tiles[tile].info.external_tile_mask[tile_right] == 1) {
+        clover_unpack_right(globals, right_rcv_buffer, fields, tile, depth, left_right_offset);
+      }
+    }
+  }
+
+  message_count = 0;
+  for (MPI_Request &i : request)
+    i = {};
+
+  if (globals.chunk.chunk_neighbours[chunk_bottom] != external_face) {
+    // do bottom exchanges
+    for (int tile = 0; tile < globals.config.tiles_per_chunk; ++tile) {
+      if (globals.chunk.tiles[tile].info.external_tile_mask[tile_bottom] == 1) {
+        clover_pack_bottom(globals, bottom_snd_buffer, tile, fields, depth, bottom_top_offset);
+      }
+    }
+
+    // send message downwards
+#pragma omp target update if (stage) from(bottom_snd[ : bottom_snd_buffer.N()])
+#pragma omp target data if (!stage) use_device_ptr(bottom_snd, bottom_rcv)
+    clover_send_recv_message_bottom(globals, bottom_snd, bottom_rcv, end_pack_index_bottom_top, 3, 4, request[message_count],
+                                    request[message_count + 1]);
+    message_count += 2;
+  }
+
+  if (globals.chunk.chunk_neighbours[chunk_top] != external_face) {
+    // do top exchanges
+    for (int tile = 0; tile < globals.config.tiles_per_chunk; ++tile) {
+      if (globals.chunk.tiles[tile].info.external_tile_mask[tile_top] == 1) {
+        clover_pack_top(globals, top_snd_buffer, tile, fields, depth, bottom_top_offset);
+      }
+    }
+
+    // send message upwards
+#pragma omp target update if (stage) from(top_snd[ : top_snd_buffer.N()])
+#pragma omp target data if (!stage) use_device_ptr(top_snd, top_rcv)
+    clover_send_recv_message_top(globals, top_snd, top_rcv, end_pack_index_bottom_top, 4, 3, request[message_count],
+                                 request[message_count + 1]);
+    message_count += 2;
+  }
+
+  // need to make a call to wait / sync
+  MPI_Waitall(message_count, request, MPI_STATUS_IGNORE);
+
+  // Copy back to the device
+
+  // unpack in top direction
+  if (globals.chunk.chunk_neighbours[chunk_top] != external_face) {
+#pragma omp target update to(top_rcv[ : top_rcv_buffer.N()]) if (stage)
+    for (int tile = 0; tile < globals.config.tiles_per_chunk; ++tile) {
+      if (globals.chunk.tiles[tile].info.external_tile_mask[tile_top] == 1) {
+        clover_unpack_top(globals, top_rcv_buffer, fields, tile, depth, bottom_top_offset);
+      }
+    }
+  }
+
+  // unpack in bottom direction
+  if (globals.chunk.chunk_neighbours[chunk_bottom] != external_face) {
+#pragma omp target update to(bottom_rcv[ : bottom_rcv_buffer.N()]) if (stage)
+    for (int tile = 0; tile < globals.config.tiles_per_chunk; ++tile) {
+      if (globals.chunk.tiles[tile].info.external_tile_mask[tile_bottom] == 1) {
+        clover_unpack_bottom(globals, bottom_rcv_buffer, fields, tile, depth, bottom_top_offset);
+      }
+    }
+  }
+
+#pragma omp target exit data map(release : left_rcv[ : 0]) map(release : left_snd[ : 0]) map(release : right_rcv[ : 0])                    \
+    map(release : right_snd[ : 0]) map(release : top_rcv[ : 0]) map(release : top_snd[ : 0]) map(release : bottom_rcv[ : 0])               \
+    map(release : bottom_snd[ : 0])
+}
+
+void clover_send_recv_message_left(global_variables &globals, double *left_snd_buffer, double *left_rcv_buffer, int total_size,
+                                   int tag_send, int tag_recv, MPI_Request &req_send, MPI_Request &req_recv) {
+  int left_task = globals.chunk.chunk_neighbours[chunk_left] - 1;
+  MPI_Isend(left_snd_buffer, total_size, MPI_DOUBLE, left_task, tag_send, MPI_COMM_WORLD, &req_send);
+  MPI_Irecv(left_rcv_buffer, total_size, MPI_DOUBLE, left_task, tag_recv, MPI_COMM_WORLD, &req_recv);
+}
+void clover_send_recv_message_right(global_variables &globals, double *right_snd_buffer, double *right_rcv_buffer, int total_size,
+                                    int tag_send, int tag_recv, MPI_Request &req_send, MPI_Request &req_recv) {
+  int right_task = globals.chunk.chunk_neighbours[chunk_right] - 1;
+  MPI_Isend(right_snd_buffer, total_size, MPI_DOUBLE, right_task, tag_send, MPI_COMM_WORLD, &req_send);
+  MPI_Irecv(right_rcv_buffer, total_size, MPI_DOUBLE, right_task, tag_recv, MPI_COMM_WORLD, &req_recv);
+}
+void clover_send_recv_message_top(global_variables &globals, double *top_snd_buffer, double *top_rcv_buffer, int total_size, int tag_send,
+                                  int tag_recv, MPI_Request &req_send, MPI_Request &req_recv) {
+  int top_task = globals.chunk.chunk_neighbours[chunk_top] - 1;
+  MPI_Isend(top_snd_buffer, total_size, MPI_DOUBLE, top_task, tag_send, MPI_COMM_WORLD, &req_send);
+  MPI_Irecv(top_rcv_buffer, total_size, MPI_DOUBLE, top_task, tag_recv, MPI_COMM_WORLD, &req_recv);
+}
+void clover_send_recv_message_bottom(global_variables &globals, double *bottom_snd_buffer, double *bottom_rcv_buffer, int total_size,
+                                     int tag_send, int tag_recv, MPI_Request &req_send, MPI_Request &req_recv) {
+  int bottom_task = globals.chunk.chunk_neighbours[chunk_bottom] - 1;
+  MPI_Isend(bottom_snd_buffer, total_size, MPI_DOUBLE, bottom_task, tag_send, MPI_COMM_WORLD, &req_send);
+  MPI_Irecv(bottom_rcv_buffer, total_size, MPI_DOUBLE, bottom_task, tag_recv, MPI_COMM_WORLD, &req_recv);
+}

--- a/src/acc/comms_kernel.cpp
+++ b/src/acc/comms_kernel.cpp
@@ -114,6 +114,7 @@ void clover_exchange(global_variables &globals, const int fields[NUM_FIELDS], co
     create(right_rcv[ : right_rcv_buffer.N()]) create(right_snd[ : right_snd_buffer.N()])                                        \
     create(top_rcv[ : top_rcv_buffer.N()]) create(top_snd[ : top_snd_buffer.N()])                                                \
     create(bottom_rcv[ : bottom_rcv_buffer.N()]) create(bottom_snd[ : bottom_snd_buffer.N()])
+  {
 
   if (globals.chunk.chunk_neighbours[chunk_left] != external_face) {
     // do left exchanges
@@ -232,6 +233,7 @@ void clover_exchange(global_variables &globals, const int fields[NUM_FIELDS], co
         clover_unpack_bottom(globals, bottom_rcv_buffer, fields, tile, depth, bottom_top_offset);
       }
     }
+  }
   }
 
 #pragma acc exit data delete(left_rcv, left_snd, right_rcv, right_snd, \

--- a/src/acc/comms_kernel.cpp
+++ b/src/acc/comms_kernel.cpp
@@ -110,11 +110,10 @@ void clover_exchange(global_variables &globals, const int fields[NUM_FIELDS], co
 
   bool stage = globals.config.staging_buffer;
 
-#pragma acc data create(left_rcv[ : left_rcv_buffer.N()]) create(left_snd[ : left_snd_buffer.N()])                  \
+#pragma acc enter data create(left_rcv[ : left_rcv_buffer.N()]) create(left_snd[ : left_snd_buffer.N()])                  \
     create(right_rcv[ : right_rcv_buffer.N()]) create(right_snd[ : right_snd_buffer.N()])                                        \
     create(top_rcv[ : top_rcv_buffer.N()]) create(top_snd[ : top_snd_buffer.N()])                                                \
     create(bottom_rcv[ : bottom_rcv_buffer.N()]) create(bottom_snd[ : bottom_snd_buffer.N()])
-  {
 
   if (globals.chunk.chunk_neighbours[chunk_left] != external_face) {
     // do left exchanges
@@ -127,7 +126,7 @@ void clover_exchange(global_variables &globals, const int fields[NUM_FIELDS], co
 
     // send and recv messages to the left
 #pragma acc update if (stage) host(left_snd[ : left_snd_buffer.N()])
-#pragma acc data if (!stage) deviceptr(left_snd, left_rcv)
+#pragma acc host_data if (!stage) use_device(left_snd, left_rcv)
     clover_send_recv_message_left(globals, left_snd, left_rcv, end_pack_index_left_right, 1, 2, request[message_count],
                                   request[message_count + 1]);
     message_count += 2;
@@ -143,7 +142,7 @@ void clover_exchange(global_variables &globals, const int fields[NUM_FIELDS], co
 
     // send message to the right
 #pragma acc update if (stage) host(right_snd[ : right_snd_buffer.N()])
-#pragma acc data if (!stage) deviceptr(right_snd, right_rcv)
+#pragma acc host_data if (!stage) use_device(right_snd, right_rcv)
     clover_send_recv_message_right(globals, right_snd, right_rcv, end_pack_index_left_right, 2, 1, request[message_count],
                                    request[message_count + 1]);
     message_count += 2;
@@ -188,7 +187,7 @@ void clover_exchange(global_variables &globals, const int fields[NUM_FIELDS], co
 
     // send message downwards
 #pragma acc update if (stage) host(bottom_snd[ : bottom_snd_buffer.N()])
-#pragma acc data if (!stage) deviceptr(bottom_snd, bottom_rcv)
+#pragma acc host_data if (!stage) use_device(bottom_snd, bottom_rcv)
     clover_send_recv_message_bottom(globals, bottom_snd, bottom_rcv, end_pack_index_bottom_top, 3, 4, request[message_count],
                                     request[message_count + 1]);
     message_count += 2;
@@ -204,7 +203,7 @@ void clover_exchange(global_variables &globals, const int fields[NUM_FIELDS], co
 
     // send message upwards
 #pragma acc update if (stage) host(top_snd[ : top_snd_buffer.N()])
-#pragma acc data if (!stage) deviceptr(top_snd, top_rcv)
+#pragma acc host_data if (!stage) use_device(top_snd, top_rcv)
     clover_send_recv_message_top(globals, top_snd, top_rcv, end_pack_index_bottom_top, 4, 3, request[message_count],
                                  request[message_count + 1]);
     message_count += 2;
@@ -233,7 +232,6 @@ void clover_exchange(global_variables &globals, const int fields[NUM_FIELDS], co
         clover_unpack_bottom(globals, bottom_rcv_buffer, fields, tile, depth, bottom_top_offset);
       }
     }
-  }
   }
 
 #pragma acc exit data delete(left_rcv, left_snd, right_rcv, right_snd, \

--- a/src/acc/context.h
+++ b/src/acc/context.h
@@ -1,0 +1,150 @@
+/*
+ Crown Copyright 2012 AWE.
+
+ This file is part of CloverLeaf.
+
+ CloverLeaf is free software: you can redistribute it and/or modify it under
+ the terms of the GNU General Public License as published by the
+ Free Software Foundation, either version 3 of the License, or (at your option)
+ any later version.
+
+ CloverLeaf is distributed in the hope that it will be useful, but
+ WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ details.
+
+ You should have received a copy of the GNU General Public License along with
+ CloverLeaf. If not, see http://www.gnu.org/licenses/.
+ */
+
+#pragma once
+
+#include <iostream>
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include "shared.h"
+
+#define SYCL_DEBUG   // enable for debugging SYCL related things, also syncs kernel calls
+#define SYNC_KERNELS // enable for fully synchronous (e.g queue.wait_and_throw()) kernel calls
+#define USE_COND_TARGET
+#ifdef USE_COND_TARGET
+  #define clover_use_target(cond) if (target : (cond))
+#else
+  #define clover_use_target(cond) /*no-op*/
+#endif
+
+namespace clover {
+
+struct context {
+  bool use_target;
+};
+
+template <typename T> static inline T *alloc(size_t count) { return static_cast<T *>(std::malloc(count * sizeof(T))); }
+
+template <typename T> struct Buffer1D {
+  size_t size;
+  T *data;
+  Buffer1D(context &, size_t size) : size(size), data(alloc<T>(size)) {}
+  Buffer1D(Buffer1D &&other) noexcept : size(other.size), data(std::exchange(other.data, nullptr)) {}
+  Buffer1D(const Buffer1D<T> &that) : size(that.size), data(that.data) {}
+  ~Buffer1D() { std::free(data); }
+
+  T &operator[](size_t i) const { return data[i]; }
+  [[nodiscard]] constexpr size_t N() const { return size; }
+  T *actual() { return data; }
+
+  // alternatively, replace both assignment operators with
+  Buffer1D<T> &operator=(Buffer1D<T> other) noexcept {
+    std::swap(data, other.data);
+    std::swap(size, other.size);
+    return *this;
+  }
+
+  //  Buffer1D &operator=(Buffer1D &&other) noexcept {
+  //    size = other.size;
+  //    std::swap(data, other.data);
+  //    return *this;
+  //  }
+  //  Buffer1D<T> &operator=(const Buffer1D<T> &other) {
+  //    if (this != &other) {
+  //      delete[] data;
+  //      std::copy(other.data, other.data + size, data);
+  //      size = other.size;
+  //    }
+  //    return *this;
+  //  }
+
+  template <size_t D> [[nodiscard]] size_t extent() const {
+    static_assert(D < 1);
+    return size;
+  }
+
+  std::vector<T> mirrored() const {
+    std::vector<T> buffer(size);
+    std::copy(data, data + buffer.size(), buffer.begin());
+    return buffer;
+  }
+};
+
+template <typename T> struct Buffer2D {
+  size_t sizeX, sizeY;
+  T *data;
+  Buffer2D(context &, size_t sizeX, size_t sizeY) : sizeX(sizeX), sizeY(sizeY), data(alloc<T>(sizeX * sizeY)) {}
+  Buffer2D(Buffer2D &&other) noexcept : sizeX(other.sizeX), sizeY(other.sizeY), data(std::exchange(other.data, nullptr)) {}
+  Buffer2D(const Buffer2D<T> &that) : sizeX(that.sizeX), sizeY(that.sizeY), data(that.data) {}
+  ~Buffer2D() { std::free(data); }
+
+  T &operator()(size_t i, size_t j) const { return data[j + i * sizeY]; }
+  [[nodiscard]] constexpr size_t N() const { return sizeX * sizeY; }
+  [[nodiscard]] constexpr size_t nX() const { return sizeX; }
+  [[nodiscard]] constexpr size_t nY() const { return sizeY; }
+  T *actual() { return data; }
+
+  Buffer2D<T> &operator=(Buffer2D<T> other) noexcept {
+    std::swap(data, other.data);
+    std::swap(sizeX, other.sizeX);
+    std::swap(sizeY, other.sizeY);
+    return *this;
+  }
+
+  //  Buffer2D<T> &operator=(const Buffer2D<T> &other) {
+  //    if (this != &other) {
+  //      return *this = Buffer2D(other);
+  //    }
+  //  }
+  //
+  //  Buffer2D &operator=(Buffer2D &&other) noexcept {
+  //    sizeX = other.sizeX;
+  //    sizeY = other.sizeY;
+  //    std::swap(data, other.data);
+  //    return *this;
+  //  }
+
+  template <size_t D> [[nodiscard]] size_t extent() const {
+    if constexpr (D == 0) {
+      return sizeX;
+    } else if (D == 1) {
+      return sizeY;
+    } else {
+      static_assert(D < 2);
+      return 0;
+    }
+  }
+
+  std::vector<T> mirrored() const {
+    std::vector<T> buffer(sizeX * sizeY);
+    std::copy(data, data + buffer.size(), buffer.begin());
+    return buffer;
+  }
+  clover::BufferMirror2D<T> mirrored2() { return {mirrored(), extent<0>(), extent<1>()}; }
+};
+template <typename T> using StagingBuffer1D = T *;
+
+struct chunk_context {};
+
+} // namespace clover
+
+using clover::Range1d;
+using clover::Range2d;

--- a/src/acc/context.h
+++ b/src/acc/context.h
@@ -30,7 +30,7 @@
 #define SYNC_KERNELS // enable for fully synchronous (e.g queue.wait_and_throw()) kernel calls
 #define USE_COND_TARGET
 #ifdef USE_COND_TARGET
-  #define clover_use_target(cond) if (target : (cond))
+  #define clover_use_target(cond) if (cond)
 #else
   #define clover_use_target(cond) /*no-op*/
 #endif

--- a/src/acc/field_summary.cpp
+++ b/src/acc/field_summary.cpp
@@ -1,0 +1,121 @@
+/*
+ Crown Copyright 2012 AWE.
+
+ This file is part of CloverLeaf.
+
+ CloverLeaf is free software: you can redistribute it and/or modify it under
+ the terms of the GNU General Public License as published by the
+ Free Software Foundation, either version 3 of the License, or (at your option)
+ any later version.
+
+ CloverLeaf is distributed in the hope that it will be useful, but
+ WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ details.
+
+ You should have received a copy of the GNU General Public License along with
+ CloverLeaf. If not, see http://www.gnu.org/licenses/.
+ */
+
+#include "field_summary.h"
+#include "ideal_gas.h"
+#include "report.h"
+#include "timer.h"
+
+#include <cmath>
+#include <iomanip>
+
+//  @brief Fortran field summary kernel
+//  @author Wayne Gaudin
+//  @details The total mass, internal energy, kinetic energy and volume weighted
+//  pressure for the chunk is calculated.
+//  @brief Driver for the field summary kernels
+//  @author Wayne Gaudin
+//  @details The user specified field summary kernel is invoked here. A summation
+//  across all mesh chunks is then performed and the information outputed.
+//  If the run is a test problem, the final result is compared with the expected
+//  result and the difference output.
+//  Note the reference solution is the value returned from an Intel compiler with
+//  ieee options set on a single core crun.
+
+void field_summary(global_variables &globals, parallel_ &parallel) {
+
+  clover_report_step_header(globals, parallel);
+
+  double kernel_time = 0;
+  if (globals.profiler_on) kernel_time = timer();
+
+  for (int tile = 0; tile < globals.config.tiles_per_chunk; ++tile) {
+    ideal_gas(globals, tile, false);
+  }
+
+  if (globals.profiler_on) {
+    globals.profiler.ideal_gas += timer() - kernel_time;
+    kernel_time = timer();
+  }
+
+  double vol = 0.0;
+  double mass = 0.0;
+  double ie = 0.0;
+  double ke = 0.0;
+  double press = 0.0;
+
+#if SYNC_BUFFERS
+  globals.hostToDevice();
+#endif
+
+  for (int tile = 0; tile < globals.config.tiles_per_chunk; ++tile) {
+    tile_type &t = globals.chunk.tiles[tile];
+
+    int ymax = t.info.t_ymax;
+    int ymin = t.info.t_ymin;
+    int xmax = t.info.t_xmax;
+    int xmin = t.info.t_xmin;
+    field_type &field = t.field;
+
+    const size_t base_stride = field.base_stride;
+    const size_t vels_wk_stride = field.vels_wk_stride;
+
+    double *volume = field.volume.data;
+    double *density0 = field.density0.data;
+    double *energy0 = field.energy0.data;
+    double *pressure = field.pressure.data;
+    double *xvel0 = field.xvel0.data;
+    double *yvel0 = field.yvel0.data;
+
+#pragma omp target teams distribute parallel for simd clover_use_target(globals.context.use_target) map(tofrom : vol) map(tofrom : mass)   \
+    map(tofrom : ie) map(tofrom : ke) map(tofrom : press) reduction(+ : vol, mass, ie, ke, press)
+    for (int idx = 0; idx < ((ymax - ymin + 1) * (xmax - xmin + 1)); idx++) {
+      const int j = xmin + 1 + idx % (xmax - xmin + 1);
+      const int k = ymin + 1 + idx / (xmax - xmin + 1);
+      double vsqrd = 0.0;
+      for (int kv = k; kv <= k + 1; ++kv) {
+        for (int jv = j; jv <= j + 1; ++jv) {
+          vsqrd += 0.25 * (xvel0[(jv) + (kv)*vels_wk_stride] * xvel0[(jv) + (kv)*vels_wk_stride] +
+                           yvel0[(jv) + (kv)*vels_wk_stride] * yvel0[(jv) + (kv)*vels_wk_stride]);
+        }
+      }
+      double cell_vol = volume[j + (k)*base_stride];
+      double cell_mass = cell_vol * density0[j + (k)*base_stride];
+      vol += cell_vol;
+      mass += cell_mass;
+      ie += cell_mass * energy0[j + (k)*base_stride];
+      ke += cell_mass * 0.5 * vsqrd;
+      press += cell_vol * pressure[j + (k)*base_stride];
+    }
+  }
+
+#if SYNC_BUFFERS
+  globals.deviceToHost();
+#endif
+
+  clover_sum(vol);
+  clover_sum(mass);
+  clover_sum(ie);
+  clover_sum(ke);
+  clover_sum(press);
+
+  if (globals.profiler_on) globals.profiler.summary += timer() - kernel_time;
+
+  clover_report_step(globals, parallel, vol, mass, ie, ke, mass);
+}

--- a/src/acc/field_summary.cpp
+++ b/src/acc/field_summary.cpp
@@ -83,8 +83,8 @@ void field_summary(global_variables &globals, parallel_ &parallel) {
     double *xvel0 = field.xvel0.data;
     double *yvel0 = field.yvel0.data;
 
-#pragma omp target teams distribute parallel for simd clover_use_target(globals.context.use_target) map(tofrom : vol) map(tofrom : mass)   \
-    map(tofrom : ie) map(tofrom : ke) map(tofrom : press) reduction(+ : vol, mass, ie, ke, press)
+#pragma acc parallel loop gang worker vector default(present) clover_use_target(globals.context.use_target) \
+    copy(vol, mass, ie, ke, press) reduction(+ : vol, mass, ie, ke, press)
     for (int idx = 0; idx < ((ymax - ymin + 1) * (xmax - xmin + 1)); idx++) {
       const int j = xmin + 1 + idx % (xmax - xmin + 1);
       const int k = ymin + 1 + idx / (xmax - xmin + 1);

--- a/src/acc/field_summary.cpp
+++ b/src/acc/field_summary.cpp
@@ -83,8 +83,11 @@ void field_summary(global_variables &globals, parallel_ &parallel) {
     double *xvel0 = field.xvel0.data;
     double *yvel0 = field.yvel0.data;
 
-#pragma acc parallel loop gang worker vector default(present) clover_use_target(globals.context.use_target) \
-    copy(vol, mass, ie, ke, press) reduction(+ : vol, mass, ie, ke, press)
+#pragma acc parallel loop gang worker vector clover_use_target(globals.context.use_target) \
+    copy(vol, mass, ie, ke, press) reduction(+ : vol, mass, ie, ke, press)                 \
+    present(volume[ : field.volume.N()], density0[ : field.density0.N()],                  \
+            energy0[ : field.energy0.N()], pressure[ : field.pressure.N()],                \
+            xvel0[ : field.xvel0.N()], yvel0[ : field.yvel0.N()])
     for (int idx = 0; idx < ((ymax - ymin + 1) * (xmax - xmin + 1)); idx++) {
       const int j = xmin + 1 + idx % (xmax - xmin + 1);
       const int k = ymin + 1 + idx / (xmax - xmin + 1);

--- a/src/acc/finalise.cpp
+++ b/src/acc/finalise.cpp
@@ -1,0 +1,73 @@
+/*
+ Crown Copyright 2012 AWE.
+
+ This file is part of CloverLeaf.
+
+ CloverLeaf is free software: you can redistribute it and/or modify it under
+ the terms of the GNU General Public License as published by the
+ Free Software Foundation, either version 3 of the License, or (at your option)
+ any later version.
+
+ CloverLeaf is distributed in the hope that it will be useful, but
+ WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ details.
+
+ You should have received a copy of the GNU General Public License along with
+ CloverLeaf. If not, see http://www.gnu.org/licenses/.
+ */
+
+#include "finalise.h"
+
+void finalise(global_variables &globals) {
+
+  for (int tile = 0; tile < globals.config.tiles_per_chunk; ++tile) {
+
+    tile_type &t = globals.chunk.tiles[tile];
+    field_type &field = t.field;
+
+    double *density0 = field.density0.data;
+    double *density1 = field.density1.data;
+    double *energy0 = field.energy0.data;
+    double *energy1 = field.energy1.data;
+    double *pressure = field.pressure.data;
+    double *viscosity = field.viscosity.data;
+    double *soundspeed = field.soundspeed.data;
+    double *yvel0 = field.yvel0.data;
+    double *yvel1 = field.yvel1.data;
+    double *xvel0 = field.xvel0.data;
+    double *xvel1 = field.xvel1.data;
+    double *vol_flux_x = field.vol_flux_x.data;
+    double *vol_flux_y = field.vol_flux_y.data;
+    double *mass_flux_x = field.mass_flux_x.data;
+    double *mass_flux_y = field.mass_flux_y.data;
+    double *work_array1 = field.work_array1.data;
+    double *work_array2 = field.work_array2.data;
+    double *work_array3 = field.work_array3.data;
+    double *work_array4 = field.work_array4.data;
+    double *work_array5 = field.work_array5.data;
+    double *work_array6 = field.work_array6.data;
+    double *work_array7 = field.work_array7.data;
+    double *cellx = field.cellx.data;
+    double *celldx = field.celldx.data;
+    double *celly = field.celly.data;
+    double *celldy = field.celldy.data;
+    double *vertexx = field.vertexx.data;
+    double *vertexdx = field.vertexdx.data;
+    double *vertexy = field.vertexy.data;
+    double *vertexdy = field.vertexdy.data;
+    double *volume = field.volume.data;
+    double *xarea = field.xarea.data;
+    double *yarea = field.yarea.data;
+
+#pragma omp target exit data map(release : density0[ : 0]) map(release : density1[ : 0]) map(release : energy0[ : 0])                      \
+    map(release : energy1[ : 0]) map(release : pressure[ : 0]) map(release : viscosity[ : 0]) map(release : soundspeed[ : 0])              \
+    map(release : yvel0[ : 0]) map(release : yvel1[ : 0]) map(release : xvel0[ : 0]) map(release : xvel1[ : 0])                            \
+    map(release : vol_flux_x[ : 0]) map(release : vol_flux_y[ : 0]) map(release : mass_flux_x[ : 0]) map(release : mass_flux_y[ : 0])      \
+    map(release : work_array1[ : 0]) map(release : work_array2[ : 0]) map(release : work_array3[ : 0]) map(release : work_array4[ : 0])    \
+    map(release : work_array5[ : 0]) map(release : work_array6[ : 0]) map(release : work_array7[ : 0]) map(release : cellx[ : 0])          \
+    map(release : celldx[ : 0]) map(release : celly[ : 0]) map(release : celldy[ : 0]) map(release : vertexx[ : 0])                        \
+    map(release : vertexdx[ : 0]) map(release : vertexy[ : 0]) map(release : vertexdy[ : 0]) map(release : volume[ : 0])                   \
+    map(release : xarea[ : 0]) map(release : yarea[ : 0])
+  }
+}

--- a/src/acc/finalise.cpp
+++ b/src/acc/finalise.cpp
@@ -60,14 +60,9 @@ void finalise(global_variables &globals) {
     double *xarea = field.xarea.data;
     double *yarea = field.yarea.data;
 
-#pragma omp target exit data map(release : density0[ : 0]) map(release : density1[ : 0]) map(release : energy0[ : 0])                      \
-    map(release : energy1[ : 0]) map(release : pressure[ : 0]) map(release : viscosity[ : 0]) map(release : soundspeed[ : 0])              \
-    map(release : yvel0[ : 0]) map(release : yvel1[ : 0]) map(release : xvel0[ : 0]) map(release : xvel1[ : 0])                            \
-    map(release : vol_flux_x[ : 0]) map(release : vol_flux_y[ : 0]) map(release : mass_flux_x[ : 0]) map(release : mass_flux_y[ : 0])      \
-    map(release : work_array1[ : 0]) map(release : work_array2[ : 0]) map(release : work_array3[ : 0]) map(release : work_array4[ : 0])    \
-    map(release : work_array5[ : 0]) map(release : work_array6[ : 0]) map(release : work_array7[ : 0]) map(release : cellx[ : 0])          \
-    map(release : celldx[ : 0]) map(release : celly[ : 0]) map(release : celldy[ : 0]) map(release : vertexx[ : 0])                        \
-    map(release : vertexdx[ : 0]) map(release : vertexy[ : 0]) map(release : vertexdy[ : 0]) map(release : volume[ : 0])                   \
-    map(release : xarea[ : 0]) map(release : yarea[ : 0])
+#pragma acc exit data delete(density0, density1, energy0, energy1, pressure, viscosity, \
+	soundspeed, yvel0, yvel1, xvel0, xvel1, vol_flux_x, vol_flux_y, mass_flux_x, mass_flux_y, \
+    work_array1, work_array2, work_array3, work_array4, work_array5, work_array6, work_array7, \
+    cellx, celldx, celly, celldy, vertexx, vertexdx, vertexy, vertexdy, volume, xarea, yarea)
   }
 }

--- a/src/acc/flux_calc.cpp
+++ b/src/acc/flux_calc.cpp
@@ -1,0 +1,82 @@
+/*
+ Crown Copyright 2012 AWE.
+
+ This file is part of CloverLeaf.
+
+ CloverLeaf is free software: you can redistribute it and/or modify it under
+ the terms of the GNU General Public License as published by the
+ Free Software Foundation, either version 3 of the License, or (at your option)
+ any later version.
+
+ CloverLeaf is distributed in the hope that it will be useful, but
+ WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ details.
+
+ You should have received a copy of the GNU General Public License along with
+ CloverLeaf. If not, see http://www.gnu.org/licenses/.
+ */
+
+#include "flux_calc.h"
+#include "timer.h"
+
+//  @brief Fortran flux kernel.
+//  @author Wayne Gaudin
+//  @details The edge volume fluxes are calculated based on the velocity fields.
+void flux_calc_kernel(bool use_target, int x_min, int x_max, int y_min, int y_max, double dt, field_type &field) {
+
+  // DO k=y_min,y_max+1
+  //   DO j=x_min,x_max+1
+  // Note that the loops calculate one extra flux than required, but this
+  // allows loop fusion that improves performance
+
+  const int flux_x_stride = field.flux_x_stride;
+  const int flux_y_stride = field.flux_y_stride;
+  const int vels_wk_stride = field.vels_wk_stride;
+
+  double *xarea = field.xarea.data;
+  double *yarea = field.yarea.data;
+  double *xvel0 = field.xvel0.data;
+  double *yvel0 = field.yvel0.data;
+  double *xvel1 = field.xvel1.data;
+  double *yvel1 = field.yvel1.data;
+  double *vol_flux_x = field.vol_flux_x.data;
+  double *vol_flux_y = field.vol_flux_y.data;
+
+#pragma omp target teams distribute parallel for simd collapse(2) clover_use_target(use_target)
+  for (int j = (y_min + 1); j < (y_max + 1 + 2); j++) {
+    for (int i = (x_min + 1); i < (x_max + 1 + 2); i++) {
+      vol_flux_x[i + j * flux_x_stride] = 0.25 * dt * xarea[i + j * flux_x_stride] *
+                                          (xvel0[i + j * vels_wk_stride] + xvel0[(i + 0) + (j + 1) * vels_wk_stride] +
+                                           xvel1[i + j * vels_wk_stride] + xvel1[(i + 0) + (j + 1) * vels_wk_stride]);
+      vol_flux_y[i + j * flux_y_stride] = 0.25 * dt * yarea[i + j * flux_y_stride] *
+                                          (yvel0[i + j * vels_wk_stride] + yvel0[(i + 1) + (j + 0) * vels_wk_stride] +
+                                           yvel1[i + j * vels_wk_stride] + yvel1[(i + 1) + (j + 0) * vels_wk_stride]);
+    }
+  }
+}
+
+// @brief Driver for the flux kernels
+// @author Wayne Gaudin
+// @details Invokes the used specified flux kernel
+void flux_calc(global_variables &globals) {
+
+  double kernel_time = 0;
+  if (globals.profiler_on) kernel_time = timer();
+
+#if SYNC_BUFFERS
+  globals.hostToDevice();
+#endif
+
+  for (int tile = 0; tile < globals.config.tiles_per_chunk; ++tile) {
+
+    tile_type &t = globals.chunk.tiles[tile];
+    flux_calc_kernel(globals.context.use_target, t.info.t_xmin, t.info.t_xmax, t.info.t_ymin, t.info.t_ymax, globals.dt, t.field);
+  }
+
+#if SYNC_BUFFERS
+  globals.deviceToHost();
+#endif
+
+  if (globals.profiler_on) globals.profiler.flux += timer() - kernel_time;
+}

--- a/src/acc/flux_calc.cpp
+++ b/src/acc/flux_calc.cpp
@@ -43,7 +43,7 @@ void flux_calc_kernel(bool use_target, int x_min, int x_max, int y_min, int y_ma
   double *vol_flux_x = field.vol_flux_x.data;
   double *vol_flux_y = field.vol_flux_y.data;
 
-#pragma omp target teams distribute parallel for simd collapse(2) clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector default(present) collapse(2) clover_use_target(use_target)
   for (int j = (y_min + 1); j < (y_max + 1 + 2); j++) {
     for (int i = (x_min + 1); i < (x_max + 1 + 2); i++) {
       vol_flux_x[i + j * flux_x_stride] = 0.25 * dt * xarea[i + j * flux_x_stride] *

--- a/src/acc/flux_calc.cpp
+++ b/src/acc/flux_calc.cpp
@@ -43,7 +43,11 @@ void flux_calc_kernel(bool use_target, int x_min, int x_max, int y_min, int y_ma
   double *vol_flux_x = field.vol_flux_x.data;
   double *vol_flux_y = field.vol_flux_y.data;
 
-#pragma acc parallel loop gang worker vector default(present) collapse(2) clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector collapse(2) clover_use_target(use_target) \
+    present(xarea[ : field.xarea.N()], yarea[ : field.yarea.N()],                      \
+            xvel0[ : field.xvel0.N()], xvel1[ : field.xvel1.N()],                      \
+            yvel0[ : field.yvel0.N()], yvel1[ : field.yvel1.N()],                      \
+            vol_flux_x[ : field.vol_flux_x.N()], vol_flux_y[ : field.vol_flux_y.N()])
   for (int j = (y_min + 1); j < (y_max + 1 + 2); j++) {
     for (int i = (x_min + 1); i < (x_max + 1 + 2); i++) {
       vol_flux_x[i + j * flux_x_stride] = 0.25 * dt * xarea[i + j * flux_x_stride] *

--- a/src/acc/generate_chunk.cpp
+++ b/src/acc/generate_chunk.cpp
@@ -1,0 +1,165 @@
+/*
+ Crown Copyright 2012 AWE.
+
+ This file is part of CloverLeaf.
+
+ CloverLeaf is free software: you can redistribute it and/or modify it under
+ the terms of the GNU General Public License as published by the
+ Free Software Foundation, either version 3 of the License, or (at your option)
+ any later version.
+
+ CloverLeaf is distributed in the hope that it will be useful, but
+ WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ details.
+
+ You should have received a copy of the GNU General Public License along with
+ CloverLeaf. If not, see http://www.gnu.org/licenses/.
+ */
+
+//  @brief Mesh chunk generation driver
+//  @author Wayne Gaudin
+//  @details Invoked the users specified chunk generator.
+//  @brief Mesh chunk generation driver
+//  @author Wayne Gaudin
+//  @details Invoked the users specified chunk generator.
+
+#include "generate_chunk.h"
+#include <cmath>
+
+void generate_chunk(const int tile, global_variables &globals) {
+
+  // Need to copy the host array of state input data into a device array
+  clover::Buffer1D<double> state_density_buffer(globals.context, globals.config.number_of_states);
+  clover::Buffer1D<double> state_energy_buffer(globals.context, globals.config.number_of_states);
+  clover::Buffer1D<double> state_xvel_buffer(globals.context, globals.config.number_of_states);
+  clover::Buffer1D<double> state_yvel_buffer(globals.context, globals.config.number_of_states);
+  clover::Buffer1D<double> state_xmin_buffer(globals.context, globals.config.number_of_states);
+  clover::Buffer1D<double> state_xmax_buffer(globals.context, globals.config.number_of_states);
+  clover::Buffer1D<double> state_ymin_buffer(globals.context, globals.config.number_of_states);
+  clover::Buffer1D<double> state_ymax_buffer(globals.context, globals.config.number_of_states);
+  clover::Buffer1D<double> state_radius_buffer(globals.context, globals.config.number_of_states);
+  clover::Buffer1D<int> state_geometry_buffer(globals.context, globals.config.number_of_states);
+
+  // Copy the data to the new views
+  for (int state = 0; state < globals.config.number_of_states; ++state) {
+    state_density_buffer[state] = globals.config.states[state].density;
+    state_energy_buffer[state] = globals.config.states[state].energy;
+    state_xvel_buffer[state] = globals.config.states[state].xvel;
+    state_yvel_buffer[state] = globals.config.states[state].yvel;
+    state_xmin_buffer[state] = globals.config.states[state].xmin;
+    state_xmax_buffer[state] = globals.config.states[state].xmax;
+    state_ymin_buffer[state] = globals.config.states[state].ymin;
+    state_ymax_buffer[state] = globals.config.states[state].ymax;
+    state_radius_buffer[state] = globals.config.states[state].radius;
+    state_geometry_buffer[state] = globals.config.states[state].geometry;
+  }
+
+  // Kokkos::deep_copy (TO, FROM)
+
+  const int x_min = globals.chunk.tiles[tile].info.t_xmin;
+  const int x_max = globals.chunk.tiles[tile].info.t_xmax;
+  const int y_min = globals.chunk.tiles[tile].info.t_ymin;
+  const int y_max = globals.chunk.tiles[tile].info.t_ymax;
+
+  int xrange = (x_max + 2) - (x_min - 2) + 1;
+  int yrange = (y_max + 2) - (y_min - 2) + 1;
+
+  // Take a reference to the lowest structure, as Kokkos device cannot necessarily chase through the structure.
+
+  field_type &field = globals.chunk.tiles[tile].field;
+
+  const double state_energy_0 = state_energy_buffer[0];
+  const double state_density_0 = state_density_buffer[0];
+  const double state_xvel_0 = state_xvel_buffer[0];
+  const double state_yvel_0 = state_yvel_buffer[0];
+
+  const int base_stride = field.base_stride;
+  const int vels_wk_stride = field.vels_wk_stride;
+
+  // State 1 is always the background state
+  double *energy0 = field.energy0.data;
+  double *density0 = field.density0.data;
+  double *xvel0 = field.xvel0.data;
+  double *yvel0 = field.yvel0.data;
+
+#pragma omp target teams distribute parallel for simd collapse(2) clover_use_target(globals.context.use_target)
+  for (int j = 0; j < (yrange); j++) {
+    for (int i = 0; i < (xrange); i++) {
+      energy0[i + j * base_stride] = state_energy_0;
+      density0[i + j * base_stride] = state_density_0;
+      xvel0[i + j * vels_wk_stride] = state_xvel_0;
+      yvel0[i + j * vels_wk_stride] = state_yvel_0;
+    }
+  }
+
+  for (int state = 1; state < globals.config.number_of_states; ++state) {
+
+    double *cellx = field.cellx.data;
+    double *celly = field.celly.data;
+
+    double *vertexx = field.vertexx.data;
+    double *vertexy = field.vertexy.data;
+
+    const double *state_density = state_density_buffer.data;
+    const double *state_energy = state_energy_buffer.data;
+    const double *state_xvel = state_xvel_buffer.data;
+    const double *state_yvel = state_yvel_buffer.data;
+    const double *state_xmin = state_xmin_buffer.data;
+    const double *state_xmax = state_xmax_buffer.data;
+    const double *state_ymin = state_ymin_buffer.data;
+    const double *state_ymax = state_ymax_buffer.data;
+    const double *state_radius = state_radius_buffer.data;
+    const int *state_geometry = state_geometry_buffer.data;
+
+#pragma omp target teams distribute parallel for simd collapse(2) clover_use_target(globals.context.use_target)                            \
+    map(to : state_density[ : state_density_buffer.N()]) map(to : state_energy[ : state_energy_buffer.N()])                                \
+    map(to : state_xvel[ : state_xvel_buffer.N()]) map(to : state_yvel[ : state_yvel_buffer.N()])                                          \
+    map(to : state_xmin[ : state_xmin_buffer.N()]) map(to : state_xmax[ : state_xmax_buffer.N()])                                          \
+    map(to : state_ymin[ : state_ymin_buffer.N()]) map(to : state_ymax[ : state_ymax_buffer.N()])                                          \
+    map(to : state_radius[ : state_radius_buffer.N()]) map(to : state_geometry[ : state_geometry_buffer.N()])
+    for (int j = 0; j < (yrange); j++) {
+      for (int i = 0; i < (xrange); i++) {
+        double x_cent = state_xmin[state];
+        double y_cent = state_ymin[state];
+        if (state_geometry[state] == g_rect) {
+          if (vertexx[i + 1] >= state_xmin[state] && vertexx[i] < state_xmax[state]) {
+            if (vertexy[j + 1] >= state_ymin[state] && vertexy[j] < state_ymax[state]) {
+              energy0[i + j * base_stride] = state_energy[state];
+              density0[i + j * base_stride] = state_density[state];
+              for (int kt = j; kt <= j + 1; ++kt) {
+                for (int jt = i; jt <= i + 1; ++jt) {
+                  xvel0[jt + kt * vels_wk_stride] = state_xvel[state];
+                  yvel0[jt + kt * vels_wk_stride] = state_yvel[state];
+                }
+              }
+            }
+          }
+        } else if (state_geometry[state] == g_circ) {
+          double radius = sqrt((cellx[i] - x_cent) * (cellx[i] - x_cent) + (celly[j] - y_cent) * (celly[j] - y_cent));
+          if (radius <= state_radius[state]) {
+            energy0[i + j * base_stride] = state_energy[state];
+            density0[i + j * base_stride] = state_density[state];
+            for (int kt = j; kt <= j + 1; ++kt) {
+              for (int jt = i; jt <= i + 1; ++jt) {
+                xvel0[jt + kt * vels_wk_stride] = state_xvel[state];
+                yvel0[jt + kt * vels_wk_stride] = state_yvel[state];
+              }
+            }
+          }
+        } else if (state_geometry[state] == g_point) {
+          if (vertexx[i] == x_cent && vertexy[j] == y_cent) {
+            energy0[i + j * base_stride] = state_energy[state];
+            density0[i + j * base_stride] = state_density[state];
+            for (int kt = j; kt <= j + 1; ++kt) {
+              for (int jt = i; jt <= i + 1; ++jt) {
+                xvel0[jt + kt * vels_wk_stride] = state_xvel[state];
+                yvel0[jt + kt * vels_wk_stride] = state_yvel[state];
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/acc/generate_chunk.cpp
+++ b/src/acc/generate_chunk.cpp
@@ -112,8 +112,6 @@ void generate_chunk(const int tile, global_variables &globals) {
     const double *state_radius = state_radius_buffer.data;
     const int *state_geometry = state_geometry_buffer.data;
 
-/* TODO NVHPC says it can't parallelize the inner for loops
- * We can try forcing if the index calcs are unique */
 #pragma acc parallel loop gang worker vector default(present) collapse(2) clover_use_target(globals.context.use_target)                            \
     copyin(state_density[ : state_density_buffer.N()]) copyin(state_energy[ : state_energy_buffer.N()])                                \
     copyin(state_xvel[ : state_xvel_buffer.N()]) copyin(state_yvel[ : state_yvel_buffer.N()])                                          \

--- a/src/acc/generate_chunk.cpp
+++ b/src/acc/generate_chunk.cpp
@@ -83,7 +83,9 @@ void generate_chunk(const int tile, global_variables &globals) {
   double *xvel0 = field.xvel0.data;
   double *yvel0 = field.yvel0.data;
 
-#pragma acc parallel loop gang worker vector default(present) collapse(2) clover_use_target(globals.context.use_target)
+#pragma acc parallel loop gang worker vector collapse(2) clover_use_target(globals.context.use_target) \
+    present(energy0[ : field.energy0.N()], density0[ : field.density0.N()],                            \
+            xvel0[ : field.xvel0.N()], yvel0[: field.yvel0.N()])
   for (int j = 0; j < (yrange); j++) {
     for (int i = 0; i < (xrange); i++) {
       energy0[i + j * base_stride] = state_energy_0;
@@ -112,12 +114,14 @@ void generate_chunk(const int tile, global_variables &globals) {
     const double *state_radius = state_radius_buffer.data;
     const int *state_geometry = state_geometry_buffer.data;
 
-#pragma acc parallel loop gang worker vector default(present) collapse(2) clover_use_target(globals.context.use_target)                            \
+#pragma acc parallel loop gang worker vector collapse(2) clover_use_target(globals.context.use_target)                                 \
     copyin(state_density[ : state_density_buffer.N()]) copyin(state_energy[ : state_energy_buffer.N()])                                \
     copyin(state_xvel[ : state_xvel_buffer.N()]) copyin(state_yvel[ : state_yvel_buffer.N()])                                          \
     copyin(state_xmin[ : state_xmin_buffer.N()]) copyin(state_xmax[ : state_xmax_buffer.N()])                                          \
     copyin(state_ymin[ : state_ymin_buffer.N()]) copyin(state_ymax[ : state_ymax_buffer.N()])                                          \
-    copyin(state_radius[ : state_radius_buffer.N()]) copyin(state_geometry[ : state_geometry_buffer.N()])
+    copyin(state_radius[ : state_radius_buffer.N()]) copyin(state_geometry[ : state_geometry_buffer.N()])                              \
+    present(energy0[ : field.energy0.N()], density0[ : field.density0.N()], xvel0[ : field.xvel0.N()], yvel0[: field.yvel0.N()],       \
+            cellx[ : field.cellx.N()], celly[ : field.celly.N()], vertexx[ : field.vertexx.N()], vertexy[ : field.vertexy.N()])
     for (int j = 0; j < (yrange); j++) {
       for (int i = 0; i < (xrange); i++) {
         double x_cent = state_xmin[state];

--- a/src/acc/ideal_gas.cpp
+++ b/src/acc/ideal_gas.cpp
@@ -1,0 +1,81 @@
+/*
+ Crown Copyright 2012 AWE.
+
+ This file is part of CloverLeaf.
+
+ CloverLeaf is free software: you can redistribute it and/or modify it under
+ the terms of the GNU General Public License as published by the
+ Free Software Foundation, either version 3 of the License, or (at your option)
+ any later version.
+
+ CloverLeaf is distributed in the hope that it will be useful, but
+ WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ details.
+
+ You should have received a copy of the GNU General Public License along with
+ CloverLeaf. If not, see http://www.gnu.org/licenses/.
+ */
+
+#include "ideal_gas.h"
+#include "context.h"
+#include <cmath>
+
+//  @brief Fortran ideal gas kernel.
+//  @author Wayne Gaudin
+//  @details Calculates the pressure and sound speed for the mesh chunk using
+//  the ideal gas equation of state, with a fixed gamma of 1.4.
+void ideal_gas_kernel(bool use_target, int x_min, int x_max, int y_min, int y_max, field_type &field,
+                      clover::Buffer2D<double> &density_buffer, clover::Buffer2D<double> &energy_buffer) {
+
+  // std::cout <<" ideal_gas(" << x_min+1 << ","<< y_min+1<< ","<< x_max+2<< ","<< y_max +2  << ")" << std::endl;
+  //  DO k=y_min,y_max
+  //    DO j=x_min,x_max
+
+  //	Kokkos::MDRangePolicy <Kokkos::Rank<2>> policy({x_min + 1, y_min + 1}, {x_max + 2, y_max + 2});
+
+  const size_t base_stride = field.base_stride;
+
+  double *density = density_buffer.data;
+  double *energy = energy_buffer.data;
+  double *pressure = field.pressure.data;
+  double *soundspeed = field.soundspeed.data;
+
+#pragma omp target teams distribute parallel for simd collapse(2) clover_use_target(use_target)
+  for (int j = (y_min + 1); j < (y_max + 2); j++) {
+    for (int i = (x_min + 1); i < (x_max + 2); i++) {
+      double v = 1.0 / density[i + j * base_stride];
+      pressure[i + j * base_stride] = (1.4 - 1.0) * density[i + j * base_stride] * energy[i + j * base_stride];
+      double pressurebyenergy = (1.4 - 1.0) * density[i + j * base_stride];
+      double pressurebyvolume = -density[i + j * base_stride] * pressure[i + j * base_stride];
+      double sound_speed_squared = v * v * (pressure[i + j * base_stride] * pressurebyenergy - pressurebyvolume);
+      soundspeed[i + j * base_stride] = std::sqrt(sound_speed_squared);
+    }
+  };
+}
+
+//  @brief Ideal gas kernel driver
+//  @author Wayne Gaudin
+//  @details Invokes the user specified kernel for the ideal gas equation of
+//  state using the specified time level data.
+
+void ideal_gas(global_variables &globals, const int tile, bool predict) {
+
+  tile_type &t = globals.chunk.tiles[tile];
+
+#if SYNC_BUFFERS
+  globals.hostToDevice();
+#endif
+
+  if (!predict) {
+    ideal_gas_kernel(globals.context.use_target, t.info.t_xmin, t.info.t_xmax, t.info.t_ymin, t.info.t_ymax, t.field, t.field.density0,
+                     t.field.energy0);
+  } else {
+    ideal_gas_kernel(globals.context.use_target, t.info.t_xmin, t.info.t_xmax, t.info.t_ymin, t.info.t_ymax, t.field, t.field.density1,
+                     t.field.energy1);
+  }
+
+#if SYNC_BUFFERS
+  globals.deviceToHost();
+#endif
+}

--- a/src/acc/ideal_gas.cpp
+++ b/src/acc/ideal_gas.cpp
@@ -41,7 +41,7 @@ void ideal_gas_kernel(bool use_target, int x_min, int x_max, int y_min, int y_ma
   double *pressure = field.pressure.data;
   double *soundspeed = field.soundspeed.data;
 
-#pragma omp target teams distribute parallel for simd collapse(2) clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector default(present) collapse(2) clover_use_target(use_target)
   for (int j = (y_min + 1); j < (y_max + 2); j++) {
     for (int i = (x_min + 1); i < (x_max + 2); i++) {
       double v = 1.0 / density[i + j * base_stride];

--- a/src/acc/ideal_gas.cpp
+++ b/src/acc/ideal_gas.cpp
@@ -41,7 +41,9 @@ void ideal_gas_kernel(bool use_target, int x_min, int x_max, int y_min, int y_ma
   double *pressure = field.pressure.data;
   double *soundspeed = field.soundspeed.data;
 
-#pragma acc parallel loop gang worker vector default(present) collapse(2) clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector collapse(2) clover_use_target(use_target) \
+  present(density[ : density_buffer.N()], energy[ : energy_buffer.N()],                \
+          pressure[ : field.pressure.N()], soundspeed[ : field.soundspeed.N()])
   for (int j = (y_min + 1); j < (y_max + 2); j++) {
     for (int i = (x_min + 1); i < (x_max + 2); i++) {
       double v = 1.0 / density[i + j * base_stride];

--- a/src/acc/initialise.cpp
+++ b/src/acc/initialise.cpp
@@ -1,0 +1,60 @@
+/*
+Crown Copyright 2012 AWE.
+
+This file is part of CloverLeaf.
+
+       CloverLeaf is free software: you can redistribute it and/or modify it under
+          the terms of the GNU General Public License as published by the
+              Free Software Foundation, either version 3 of the License, or (at your option)
+                                            any later version.
+
+                                        CloverLeaf is distributed in the hope that it will be useful, but
+   WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+details.
+
+You should have received a copy of the GNU General Public License along with
+CloverLeaf. If not, see http://www.gnu.org/licenses/.
+*/
+
+//  @brief Top level initialisation routine
+//  @author Wayne Gaudin
+//  @details Checks for the user input and either invokes the input reader or
+//  switches to the internal test problem. It processes the input and strips
+//  comments before writing a final input file.
+//  It then calls the start routine.
+
+#include "initialise.h"
+#include "read_input.h"
+
+#include <algorithm>
+#include <omp.h>
+#include <sstream>
+#include <string>
+
+model create_context(bool silent, const std::vector<std::string> &args) {
+
+  using device = std::pair<std::string, int>;
+  auto num_devices = omp_get_num_devices();
+  std::vector<device> devices(num_devices);
+  for (size_t i = 0; i < devices.size(); ++i)
+    devices[i] = {"target device (target:true) #" + std::to_string(i), i};
+
+#ifdef USE_COND_TARGET
+  devices.emplace_back("host device (target:false)", -1);
+#endif
+
+  auto [selected, parsed] = list_and_parse<device>(
+      silent, devices, [](const auto &d) { return d.first; }, args);
+
+  if (selected.second != -1) {
+    omp_set_default_device(selected.second);
+  }
+
+  return model{clover::context{.use_target = selected.second != -1}, "OpenMP Target", selected.second != -1, parsed};
+}
+
+void report_context(const clover::context &ctx) {
+  std::cout << " - Device: #" << omp_get_default_device() << ")"
+            << " - Target: " << (ctx.use_target ? "true" : "false") << std::endl;
+}

--- a/src/acc/initialise.cpp
+++ b/src/acc/initialise.cpp
@@ -28,14 +28,14 @@ CloverLeaf. If not, see http://www.gnu.org/licenses/.
 #include "read_input.h"
 
 #include <algorithm>
-#include <omp.h>
+#include <openacc.h>
 #include <sstream>
 #include <string>
 
 model create_context(bool silent, const std::vector<std::string> &args) {
 
   using device = std::pair<std::string, int>;
-  auto num_devices = omp_get_num_devices();
+  auto num_devices = acc_get_num_devices(acc_device_default);
   std::vector<device> devices(num_devices);
   for (size_t i = 0; i < devices.size(); ++i)
     devices[i] = {"target device (target:true) #" + std::to_string(i), i};
@@ -48,13 +48,13 @@ model create_context(bool silent, const std::vector<std::string> &args) {
       silent, devices, [](const auto &d) { return d.first; }, args);
 
   if (selected.second != -1) {
-    omp_set_default_device(selected.second);
+    acc_set_device_num(selected.second, acc_device_default);
   }
 
-  return model{clover::context{.use_target = selected.second != -1}, "OpenMP Target", selected.second != -1, parsed};
+  return model{clover::context{.use_target = selected.second != -1}, "OpenACC", selected.second != -1, parsed};
 }
 
 void report_context(const clover::context &ctx) {
-  std::cout << " - Device: #" << omp_get_default_device() << ")"
+  std::cout << " - Device: #" << acc_get_device_num(acc_device_default) << ")"
             << " - Target: " << (ctx.use_target ? "true" : "false") << std::endl;
 }

--- a/src/acc/initialise.cpp
+++ b/src/acc/initialise.cpp
@@ -57,4 +57,13 @@ model create_context(bool silent, const std::vector<std::string> &args) {
 void report_context(const clover::context &ctx) {
   std::cout << " - Device: #" << acc_get_device_num(acc_device_default) << ")"
             << " - Target: " << (ctx.use_target ? "true" : "false") << std::endl;
+
+  std::cout << " - CUDA managed memory: "
+            <<
+#ifdef CLOVER_MANAGED_ALLOC
+      "true"
+#else
+      "false"
+#endif
+            << std::endl;
 }

--- a/src/acc/initialise.cpp
+++ b/src/acc/initialise.cpp
@@ -3,13 +3,13 @@ Crown Copyright 2012 AWE.
 
 This file is part of CloverLeaf.
 
-       CloverLeaf is free software: you can redistribute it and/or modify it under
-          the terms of the GNU General Public License as published by the
-              Free Software Foundation, either version 3 of the License, or (at your option)
-                                            any later version.
+CloverLeaf is free software: you can redistribute it and/or modify it under
+the terms of the GNU General Public License as published by the
+Free Software Foundation, either version 3 of the License, or (at your option)
+any later version.
 
-                                        CloverLeaf is distributed in the hope that it will be useful, but
-   WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+CloverLeaf is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
 FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
 details.
 

--- a/src/acc/initialise_chunk.cpp
+++ b/src/acc/initialise_chunk.cpp
@@ -1,0 +1,102 @@
+/*
+ Crown Copyright 2012 AWE.
+
+ This file is part of CloverLeaf.
+
+ CloverLeaf is free software: you can redistribute it and/or modify it under
+ the terms of the GNU General Public License as published by the
+ Free Software Foundation, either version 3 of the License, or (at your option)
+ any later version.
+
+ CloverLeaf is distributed in the hope that it will be useful, but
+ WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ details.
+
+ You should have received a copy of the GNU General Public License along with
+ CloverLeaf. If not, see http://www.gnu.org/licenses/.
+ */
+
+// @brief Driver for chunk initialisation.
+// @author Wayne Gaudin
+// @details Invokes the user specified chunk initialisation kernel.
+// @brief Fortran chunk initialisation kernel.
+// @author Wayne Gaudin
+// @details Calculates mesh geometry for the mesh chunk based on the mesh size.
+
+#include "initialise_chunk.h"
+
+void initialise_chunk(const int tile, global_variables &globals) {
+
+  double dx = (globals.config.grid.xmax - globals.config.grid.xmin) / (double)(globals.config.grid.x_cells);
+  double dy = (globals.config.grid.ymax - globals.config.grid.ymin) / (double)(globals.config.grid.y_cells);
+
+  double xmin = globals.config.grid.xmin + dx * (double)(globals.chunk.tiles[tile].info.t_left - 1);
+
+  double ymin = globals.config.grid.ymin + dy * (double)(globals.chunk.tiles[tile].info.t_bottom - 1);
+
+  size_t x_min = globals.chunk.tiles[tile].info.t_xmin;
+  size_t x_max = globals.chunk.tiles[tile].info.t_xmax;
+  size_t y_min = globals.chunk.tiles[tile].info.t_ymin;
+  size_t y_max = globals.chunk.tiles[tile].info.t_ymax;
+
+  size_t xrange = (x_max + 3) - (x_min - 2) + 1;
+  size_t yrange = (y_max + 3) - (y_min - 2) + 1;
+
+  // Take a reference to the lowest structure, as Kokkos device cannot necessarily chase through the structure.
+  field_type &field = globals.chunk.tiles[tile].field;
+
+  double *vertexx = field.vertexx.data;
+  double *vertexdx = field.vertexdx.data;
+
+#pragma omp target teams distribute parallel for simd clover_use_target(globals.context.use_target)
+  for (int j = 0; j < (xrange); j++) {
+    vertexx[j] = xmin + dx * (j - 1 - x_min);
+    vertexdx[j] = dx;
+  }
+
+  double *vertexy = field.vertexy.data;
+  double *vertexdy = field.vertexdy.data;
+
+#pragma omp target teams distribute parallel for simd clover_use_target(globals.context.use_target)
+  for (int k = 0; k < (yrange); k++) {
+    vertexy[k] = ymin + dy * (k - 1 - y_min);
+    vertexdy[k] = dy;
+  }
+
+  size_t xrange1 = (x_max + 2) - (x_min - 2) + 1;
+  size_t yrange1 = (y_max + 2) - (y_min - 2) + 1;
+
+  double *cellx = field.cellx.data;
+  double *celldx = field.celldx.data;
+#pragma omp target teams distribute parallel for simd clover_use_target(globals.context.use_target)
+  for (int j = 0; j < (xrange1); j++) {
+    cellx[j] = 0.5 * (vertexx[j] + vertexx[j + 1]);
+    celldx[j] = dx;
+  }
+
+  double *celly = field.celly.data;
+  double *celldy = field.celldy.data;
+#pragma omp target teams distribute parallel for simd clover_use_target(globals.context.use_target)
+  for (int k = 0; k < (yrange1); k++) {
+    celly[k] = 0.5 * (vertexy[k] + vertexy[k + 1]);
+    celldy[k] = dy;
+  }
+
+  size_t base_stride = field.base_stride;
+  size_t flux_x_stride = field.flux_x_stride;
+  size_t flux_y_stride = field.flux_y_stride;
+
+  double *volume = field.volume.data;
+  double *xarea = field.xarea.data;
+  double *yarea = field.yarea.data;
+
+#pragma omp target teams distribute parallel for simd collapse(2) clover_use_target(globals.context.use_target)
+  for (int j = 0; j < (yrange1); j++) {
+    for (int i = 0; i < (xrange1); i++) {
+      volume[i + j * base_stride] = dx * dy;
+      xarea[i + j * flux_x_stride] = celldy[j];
+      yarea[i + j * flux_y_stride] = celldx[i];
+    }
+  }
+}

--- a/src/acc/initialise_chunk.cpp
+++ b/src/acc/initialise_chunk.cpp
@@ -49,7 +49,7 @@ void initialise_chunk(const int tile, global_variables &globals) {
   double *vertexx = field.vertexx.data;
   double *vertexdx = field.vertexdx.data;
 
-#pragma omp target teams distribute parallel for simd clover_use_target(globals.context.use_target)
+#pragma acc parallel loop gang worker vector default(present) clover_use_target(globals.context.use_target)
   for (int j = 0; j < (xrange); j++) {
     vertexx[j] = xmin + dx * (j - 1 - x_min);
     vertexdx[j] = dx;
@@ -58,7 +58,7 @@ void initialise_chunk(const int tile, global_variables &globals) {
   double *vertexy = field.vertexy.data;
   double *vertexdy = field.vertexdy.data;
 
-#pragma omp target teams distribute parallel for simd clover_use_target(globals.context.use_target)
+#pragma acc parallel loop gang worker vector default(present) clover_use_target(globals.context.use_target)
   for (int k = 0; k < (yrange); k++) {
     vertexy[k] = ymin + dy * (k - 1 - y_min);
     vertexdy[k] = dy;
@@ -69,7 +69,7 @@ void initialise_chunk(const int tile, global_variables &globals) {
 
   double *cellx = field.cellx.data;
   double *celldx = field.celldx.data;
-#pragma omp target teams distribute parallel for simd clover_use_target(globals.context.use_target)
+#pragma acc parallel loop gang worker vector default(present) clover_use_target(globals.context.use_target)
   for (int j = 0; j < (xrange1); j++) {
     cellx[j] = 0.5 * (vertexx[j] + vertexx[j + 1]);
     celldx[j] = dx;
@@ -77,7 +77,7 @@ void initialise_chunk(const int tile, global_variables &globals) {
 
   double *celly = field.celly.data;
   double *celldy = field.celldy.data;
-#pragma omp target teams distribute parallel for simd clover_use_target(globals.context.use_target)
+#pragma acc parallel loop gang worker vector default(present) clover_use_target(globals.context.use_target)
   for (int k = 0; k < (yrange1); k++) {
     celly[k] = 0.5 * (vertexy[k] + vertexy[k + 1]);
     celldy[k] = dy;
@@ -91,7 +91,7 @@ void initialise_chunk(const int tile, global_variables &globals) {
   double *xarea = field.xarea.data;
   double *yarea = field.yarea.data;
 
-#pragma omp target teams distribute parallel for simd collapse(2) clover_use_target(globals.context.use_target)
+#pragma acc parallel loop gang worker vector default(present) collapse(2) clover_use_target(globals.context.use_target)
   for (int j = 0; j < (yrange1); j++) {
     for (int i = 0; i < (xrange1); i++) {
       volume[i + j * base_stride] = dx * dy;

--- a/src/acc/initialise_chunk.cpp
+++ b/src/acc/initialise_chunk.cpp
@@ -49,7 +49,8 @@ void initialise_chunk(const int tile, global_variables &globals) {
   double *vertexx = field.vertexx.data;
   double *vertexdx = field.vertexdx.data;
 
-#pragma acc parallel loop gang worker vector default(present) clover_use_target(globals.context.use_target)
+#pragma acc parallel loop gang worker vector clover_use_target(globals.context.use_target) \
+  present(vertexx[ : field.vertexx.N()], vertexdx[ : field.vertexdx.N()])
   for (int j = 0; j < (xrange); j++) {
     vertexx[j] = xmin + dx * (j - 1 - x_min);
     vertexdx[j] = dx;
@@ -58,7 +59,8 @@ void initialise_chunk(const int tile, global_variables &globals) {
   double *vertexy = field.vertexy.data;
   double *vertexdy = field.vertexdy.data;
 
-#pragma acc parallel loop gang worker vector default(present) clover_use_target(globals.context.use_target)
+#pragma acc parallel loop gang worker vector clover_use_target(globals.context.use_target) \
+  present(vertexy[ : field.vertexy.N()], vertexdy[ : field.vertexdy.N()])
   for (int k = 0; k < (yrange); k++) {
     vertexy[k] = ymin + dy * (k - 1 - y_min);
     vertexdy[k] = dy;
@@ -69,7 +71,8 @@ void initialise_chunk(const int tile, global_variables &globals) {
 
   double *cellx = field.cellx.data;
   double *celldx = field.celldx.data;
-#pragma acc parallel loop gang worker vector default(present) clover_use_target(globals.context.use_target)
+#pragma acc parallel loop gang worker vector clover_use_target(globals.context.use_target)      \
+  present(cellx[ : field.cellx.N()], celldx[ : field.celldx.N()], vertexx[ : field.vertexx.N()])
   for (int j = 0; j < (xrange1); j++) {
     cellx[j] = 0.5 * (vertexx[j] + vertexx[j + 1]);
     celldx[j] = dx;
@@ -77,7 +80,8 @@ void initialise_chunk(const int tile, global_variables &globals) {
 
   double *celly = field.celly.data;
   double *celldy = field.celldy.data;
-#pragma acc parallel loop gang worker vector default(present) clover_use_target(globals.context.use_target)
+#pragma acc parallel loop gang worker vector clover_use_target(globals.context.use_target)      \
+  present(celly[ : field.celly.N()], celldy[ : field.celldy.N()], vertexy[ : field.vertexy.N()])
   for (int k = 0; k < (yrange1); k++) {
     celly[k] = 0.5 * (vertexy[k] + vertexy[k + 1]);
     celldy[k] = dy;
@@ -91,7 +95,9 @@ void initialise_chunk(const int tile, global_variables &globals) {
   double *xarea = field.xarea.data;
   double *yarea = field.yarea.data;
 
-#pragma acc parallel loop gang worker vector default(present) collapse(2) clover_use_target(globals.context.use_target)
+#pragma acc parallel loop gang worker vector clover_use_target(globals.context.use_target)   \
+  present(volume[ : field.volume.N()], xarea[ : field.xarea.N()], yarea[ : field.yarea.N()], \
+          celldx[ : field.celldx.N()], celldy[ : field.celldy.N()])
   for (int j = 0; j < (yrange1); j++) {
     for (int i = 0; i < (xrange1); i++) {
       volume[i + j * base_stride] = dx * dy;

--- a/src/acc/model.cmake
+++ b/src/acc/model.cmake
@@ -9,6 +9,8 @@ register_flag_optional(TARGET_DEVICE
          Refer to `nvc++ --help` for the full list"
         "")
 
+register_flag_optional(MANAGED_ALLOC "Use CUDA Managed Memory" "OFF")
+
 
 register_flag_optional(CUDA_ARCH
         "[PGI/NVHPC only] Only applicable if `TARGET_DEVICE` is set to `gpu`.
@@ -71,6 +73,11 @@ macro(setup)
 
         if (TARGET_PROCESSOR)
             register_append_cxx_flags(ANY -tp=${TARGET_PROCESSOR})
+        endif ()
+
+        if (MANAGED_ALLOC)
+            register_append_cxx_flags(ANY -gpu=managed)
+			register_definitions(CLOVER_MANAGED_ALLOC)
         endif ()
 
     endif ()

--- a/src/acc/model.cmake
+++ b/src/acc/model.cmake
@@ -43,6 +43,9 @@ register_flag_optional(TARGET_PROCESSOR
         "")
 
 macro(setup)
+	set(CMAKE_CXX_STANDARD 17)
+    set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
     find_package(OpenACC REQUIRED)
 
     if(${CMAKE_VERSION} VERSION_LESS "3.16.0")

--- a/src/acc/model.cmake
+++ b/src/acc/model.cmake
@@ -11,7 +11,6 @@ register_flag_optional(TARGET_DEVICE
 
 register_flag_optional(MANAGED_ALLOC "Use CUDA Managed Memory" "OFF")
 
-
 register_flag_optional(CUDA_ARCH
         "[PGI/NVHPC only] Only applicable if `TARGET_DEVICE` is set to `gpu`.
          Nvidia architecture in ccXY format, for example, sm_70 becomes cc70, will be passed in via `-gpu=` (e.g `cc70`)
@@ -44,6 +43,11 @@ register_flag_optional(TARGET_PROCESSOR
         Refer to `nvc++ --help` for the full list"
         "")
 
+register_flag_optional(OFFLOAD_FLAGS
+   "OpenACC Offload Flags"
+   ""
+)
+
 macro(setup)
 	set(CMAKE_CXX_STANDARD 17)
     set(CMAKE_POSITION_INDEPENDENT_CODE ON)
@@ -58,7 +62,6 @@ macro(setup)
     else()
         register_link_library(OpenACC::OpenACC_CXX)
     endif()
-
 
     # XXX NVHPC is really new so older Cmake thinks it's PGI, which is true
     if ((CMAKE_CXX_COMPILER_ID STREQUAL PGI) OR (CMAKE_CXX_COMPILER_ID STREQUAL NVHPC))
@@ -81,6 +84,11 @@ macro(setup)
         endif ()
 
     endif ()
-
+    
+    if(NOT "${OFFLOAD_FLAGS}" STREQUAL "")
+        separate_arguments(OFFLOAD_FLAGS)
+        register_append_cxx_flags(ANY ${OFFLOAD_FLAGS})
+        register_append_link_flags(${OFFLOAD_FLAGS})
+    endif()
 endmacro()
 

--- a/src/acc/model.cmake
+++ b/src/acc/model.cmake
@@ -1,0 +1,195 @@
+# Compiler ID for reference (as of CMake 3.13)
+#    Absoft = Absoft Fortran (absoft.com)
+#    ADSP = Analog VisualDSP++ (analog.com)
+#    AppleClang = Apple Clang (apple.com)
+#    ARMCC = ARM Compiler (arm.com)
+#    Bruce = Bruce C Compiler
+#    CCur = Concurrent Fortran (ccur.com)
+#    Clang = LLVM Clang (clang.llvm.org)
+#    Cray = Cray Compiler (cray.com)
+#    Embarcadero, Borland = Embarcadero (embarcadero.com)
+#    G95 = G95 Fortran (g95.org)
+#    GNU = GNU Compiler Collection (gcc.gnu.org)
+#    HP = Hewlett-Packard Compiler (hp.com)
+#    IAR = IAR Systems (iar.com)
+#    Intel = Intel Compiler (intel.com)
+#    MIPSpro = SGI MIPSpro (sgi.com)
+#    MSVC = Microsoft Visual Studio (microsoft.com)
+#    NVIDIA = NVIDIA CUDA Compiler (nvidia.com)
+#    OpenWatcom = Open Watcom (openwatcom.org)
+#    PGI = The Portland Group (pgroup.com)
+#    Flang = Flang Fortran Compiler
+#    PathScale = PathScale (pathscale.com)
+#    SDCC = Small Device C Compiler (sdcc.sourceforge.net)
+#    SunPro = Oracle Solaris Studio (oracle.com)
+#    TI = Texas Instruments (ti.com)
+#    TinyCC = Tiny C Compiler (tinycc.org)
+#    XL, VisualAge, zOS = IBM XL (ibm.com)
+
+# These are only added in CMake 3.15:
+#    ARMClang = ARM Compiler based on Clang (arm.com)
+# These are only added in CMake 3.20:
+#    NVHPC = NVIDIA HPC SDK Compiler (nvidia.com)
+# These are only added in CMake 3.21
+#    Fujitsu = Fujitsu HPC compiler (Trad mode)
+#    FujitsuClang = Fujitsu HPC compiler (Clang mode)
+
+
+# CMAKE_SYSTEM_PROCESSOR is set via `uname -p`, we have:
+# Power9 = ppc64le
+# x64    = x86_64
+# arm64  = aarch64
+#
+
+
+# predefined offload flags based on compiler id and vendor,
+# the format is (COMPILER and VENDOR must be UPPERCASE):
+# Compiler: OMP_FLAGS_OFFLOAD_<COMPILER?>_<VNEDOR?>
+
+set(OMP_FLAGS_OFFLOAD_INTEL
+        -qnextgen -fiopenmp -fopenmp-targets=spir64)
+set(OMP_FLAGS_OFFLOAD_GNU_NVIDIA
+        -foffload=nvptx-none)
+set(OMP_FLAGS_OFFLOAD_GNU_AMD
+        -foffload=amdgcn-amdhsa)
+set(OMP_FLAGS_OFFLOAD_CLANG_NVIDIA
+        -fopenmp=libomp -fopenmp-targets=nvptx64-nvidia-cuda -Xopenmp-target=nvptx64-nvidia-cuda)
+set(OMP_FLAGS_OFFLOAD_CLANG_AMD
+        -fopenmp=libomp -fopenmp-targets=amdgcn-amd-amdhsa -Xopenmp-target=amdgcn-amd-amdhsa)
+set(OMP_FLAGS_OFFLOAD_CLANG_ARCH_FLAG
+        -march=) # prefix only, arch appended by the vendor:arch tuple
+
+
+# for standard (non-offload) omp, the format is (COMPILER and ARCH must be UPPERCASE):
+# Compiler:      OMP_FLAGS_CPU_<COMPILER?>_<ARCH?>
+# Linker:   OMP_LINK_FLAGS_CPU_<COMPILER?>_<ARCH?>
+
+set(OMP_FLAGS_CPU_FUJITSU
+        -Kfast -std=c++11 -KA64FX -KSVE -KARMV8_3_A -Kzfill=100 -Kprefetch_sequential=soft -Kprefetch_line=8 -Kprefetch_line_L2=16)
+set(OMP_LINK_FLAGS_CPU_FUJITSU
+        -Kopenmp)
+
+set(OMP_FLAGS_CPU_INTEL
+        -qopt-streaming-stores=always)
+
+set(OMP_FLAGS_CPU_GNU_PPC64LE
+        -mcpu=native)
+
+set(OMP_FLAGS_CPU_XL
+        -O5 -qarch=auto -qtune=auto)
+
+set(OMP_FLAGS_CPU_NEC -O4 -finline) # CMake doesn't detect this so it's meant to be chosen by register_flag_optional(ARCH)
+
+register_flag_optional(CMAKE_CXX_COMPILER
+        "Any CXX compiler that supports OpenMP as per CMake detection (and offloading if enabled with `OFFLOAD`)"
+        "c++")
+
+register_flag_optional(ARCH
+        "This overrides CMake's CMAKE_SYSTEM_PROCESSOR detection which uses (uname -p), this is mainly for use with
+         specialised accelerators only and not to be confused with offload which is is mutually exclusive with this.
+         Supported values are:
+          - NEC"
+        "")
+
+register_flag_optional(OFFLOAD
+        "Whether to use OpenMP offload, the format is <VENDOR:ARCH?>|ON|OFF.
+        We support a small set of known offload flags for clang, gcc, and icpx.
+        However, as offload support is rapidly evolving, we recommend you directly supply them via OFFLOAD_FLAGS.
+        For example:
+          * OFFLOAD=NVIDIA:sm_60
+          * OFFLOAD=AMD:gfx906
+          * OFFLOAD=INTEL
+          * OFFLOAD=ON OFFLOAD_FLAGS=..."
+        OFF)
+
+register_flag_optional(OFFLOAD_FLAGS
+        "If OFFLOAD is enabled, this *overrides* the default offload flags"
+        "")
+
+register_flag_optional(OFFLOAD_APPEND_LINK_FLAG
+        "If enabled, this appends all resolved offload flags (OFFLOAD=<vendor:arch> or directly from OFFLOAD_FLAGS) to the link flags.
+        This is required for most offload implementations so that offload libraries can linked correctly."
+        ON)
+
+
+macro(setup)
+    find_package(OpenMP REQUIRED)
+    register_link_library(OpenMP::OpenMP_CXX) # TeaLeaf OpenMP kernels are in C, not CXX
+    set(CMAKE_CXX_STANDARD 17)
+
+    string(TOUPPER ${CMAKE_CXX_COMPILER_ID} COMPILER)
+    if (NOT ARCH)
+        string(TOUPPER ${CMAKE_SYSTEM_PROCESSOR} ARCH)
+    else ()
+        message(STATUS "Using custom arch: ${ARCH}")
+    endif ()
+
+
+    if (("${OFFLOAD}" STREQUAL OFF) OR (NOT DEFINED OFFLOAD))
+        # no offload
+
+        # resolve the CPU specific flags
+        # starting with ${COMPILER_VENDOR}_${PLATFORM_ARCH}, then try ${COMPILER_VENDOR}, and then give up
+        register_append_compiler_and_arch_specific_cxx_flags(
+                OMP_FLAGS_CPU
+                ${COMPILER}
+                ${ARCH}
+        )
+
+        register_append_compiler_and_arch_specific_link_flags(
+                OMP_LINK_FLAGS_CPU
+                ${COMPILER}
+                ${ARCH}
+        )
+
+    elseif ("${OFFLOAD}" STREQUAL ON)
+        #  offload but with custom flags
+        register_definitions(OMP_TARGET DIFFUSE_OVERLOAD)
+        separate_arguments(OFFLOAD_FLAGS)
+        set(OMP_FLAGS ${OFFLOAD_FLAGS})
+    elseif ((DEFINED OFFLOAD) AND OFFLOAD_FLAGS)
+        # offload but OFFLOAD_FLAGS overrides
+        register_definitions(OMP_TARGET DIFFUSE_OVERLOAD)
+        separate_arguments(OFFLOAD_FLAGS)
+        list(OMP_FLAGS APPEND ${OFFLOAD_FLAGS})
+    else ()
+        register_definitions(OMP_TARGET DIFFUSE_OVERLOAD)
+
+        # handle the vendor:arch value
+        string(REPLACE ":" ";" OFFLOAD_TUPLE "${OFFLOAD}")
+
+        list(LENGTH OFFLOAD_TUPLE LEN)
+        if (LEN EQUAL 1)
+            #  offload with <vendor> tuple
+            list(GET OFFLOAD_TUPLE 0 OFFLOAD_VENDOR)
+            # append OMP_FLAGS_OFFLOAD_<vendor> if  exists
+            list(APPEND OMP_FLAGS ${OMP_FLAGS_OFFLOAD_${OFFLOAD_VENDOR}})
+
+        elseif (LEN EQUAL 2)
+            #  offload with <vendor:arch> tuple
+            list(GET OFFLOAD_TUPLE 0 OFFLOAD_VENDOR)
+            list(GET OFFLOAD_TUPLE 1 OFFLOAD_ARCH)
+
+            # append OMP_FLAGS_OFFLOAD_<compiler>_<vendor> if exists
+            list(APPEND OMP_FLAGS ${OMP_FLAGS_OFFLOAD_${COMPILER}_${OFFLOAD_VENDOR}})
+            # append offload arch if OMP_FLAGS_OFFLOAD_<compiler>_ARCH_FLAG if exists
+            if (DEFINED OMP_FLAGS_OFFLOAD_${COMPILER}_ARCH_FLAG)
+                list(APPEND OMP_FLAGS
+                        "${OMP_FLAGS_OFFLOAD_${COMPILER}_ARCH_FLAG}${OFFLOAD_ARCH}")
+            endif ()
+        else ()
+            message(FATAL_ERROR "Unrecognised OFFLOAD format: `${OFFLOAD}`, consider directly using OFFLOAD_FLAGS")
+        endif ()
+
+    endif ()
+
+
+    message(STATUS "OMP CXX  flags : ${OMP_FLAGS}")
+    message(STATUS "OMP Link flags : ${OMP_LINK_FLAGS}")
+    # propagate flags to linker so that it links with the offload stuff as well
+    register_append_cxx_flags(ANY ${OMP_FLAGS})
+    if (OFFLOAD_APPEND_LINK_FLAG)
+        register_append_link_flags(${OMP_FLAGS})
+    endif ()
+endmacro()
+

--- a/src/acc/model.cmake
+++ b/src/acc/model.cmake
@@ -1,195 +1,76 @@
-# Compiler ID for reference (as of CMake 3.13)
-#    Absoft = Absoft Fortran (absoft.com)
-#    ADSP = Analog VisualDSP++ (analog.com)
-#    AppleClang = Apple Clang (apple.com)
-#    ARMCC = ARM Compiler (arm.com)
-#    Bruce = Bruce C Compiler
-#    CCur = Concurrent Fortran (ccur.com)
-#    Clang = LLVM Clang (clang.llvm.org)
-#    Cray = Cray Compiler (cray.com)
-#    Embarcadero, Borland = Embarcadero (embarcadero.com)
-#    G95 = G95 Fortran (g95.org)
-#    GNU = GNU Compiler Collection (gcc.gnu.org)
-#    HP = Hewlett-Packard Compiler (hp.com)
-#    IAR = IAR Systems (iar.com)
-#    Intel = Intel Compiler (intel.com)
-#    MIPSpro = SGI MIPSpro (sgi.com)
-#    MSVC = Microsoft Visual Studio (microsoft.com)
-#    NVIDIA = NVIDIA CUDA Compiler (nvidia.com)
-#    OpenWatcom = Open Watcom (openwatcom.org)
-#    PGI = The Portland Group (pgroup.com)
-#    Flang = Flang Fortran Compiler
-#    PathScale = PathScale (pathscale.com)
-#    SDCC = Small Device C Compiler (sdcc.sourceforge.net)
-#    SunPro = Oracle Solaris Studio (oracle.com)
-#    TI = Texas Instruments (ti.com)
-#    TinyCC = Tiny C Compiler (tinycc.org)
-#    XL, VisualAge, zOS = IBM XL (ibm.com)
-
-# These are only added in CMake 3.15:
-#    ARMClang = ARM Compiler based on Clang (arm.com)
-# These are only added in CMake 3.20:
-#    NVHPC = NVIDIA HPC SDK Compiler (nvidia.com)
-# These are only added in CMake 3.21
-#    Fujitsu = Fujitsu HPC compiler (Trad mode)
-#    FujitsuClang = Fujitsu HPC compiler (Clang mode)
-
-
-# CMAKE_SYSTEM_PROCESSOR is set via `uname -p`, we have:
-# Power9 = ppc64le
-# x64    = x86_64
-# arm64  = aarch64
-#
-
-
-# predefined offload flags based on compiler id and vendor,
-# the format is (COMPILER and VENDOR must be UPPERCASE):
-# Compiler: OMP_FLAGS_OFFLOAD_<COMPILER?>_<VNEDOR?>
-
-set(OMP_FLAGS_OFFLOAD_INTEL
-        -qnextgen -fiopenmp -fopenmp-targets=spir64)
-set(OMP_FLAGS_OFFLOAD_GNU_NVIDIA
-        -foffload=nvptx-none)
-set(OMP_FLAGS_OFFLOAD_GNU_AMD
-        -foffload=amdgcn-amdhsa)
-set(OMP_FLAGS_OFFLOAD_CLANG_NVIDIA
-        -fopenmp=libomp -fopenmp-targets=nvptx64-nvidia-cuda -Xopenmp-target=nvptx64-nvidia-cuda)
-set(OMP_FLAGS_OFFLOAD_CLANG_AMD
-        -fopenmp=libomp -fopenmp-targets=amdgcn-amd-amdhsa -Xopenmp-target=amdgcn-amd-amdhsa)
-set(OMP_FLAGS_OFFLOAD_CLANG_ARCH_FLAG
-        -march=) # prefix only, arch appended by the vendor:arch tuple
-
-
-# for standard (non-offload) omp, the format is (COMPILER and ARCH must be UPPERCASE):
-# Compiler:      OMP_FLAGS_CPU_<COMPILER?>_<ARCH?>
-# Linker:   OMP_LINK_FLAGS_CPU_<COMPILER?>_<ARCH?>
-
-set(OMP_FLAGS_CPU_FUJITSU
-        -Kfast -std=c++11 -KA64FX -KSVE -KARMV8_3_A -Kzfill=100 -Kprefetch_sequential=soft -Kprefetch_line=8 -Kprefetch_line_L2=16)
-set(OMP_LINK_FLAGS_CPU_FUJITSU
-        -Kopenmp)
-
-set(OMP_FLAGS_CPU_INTEL
-        -qopt-streaming-stores=always)
-
-set(OMP_FLAGS_CPU_GNU_PPC64LE
-        -mcpu=native)
-
-set(OMP_FLAGS_CPU_XL
-        -O5 -qarch=auto -qtune=auto)
-
-set(OMP_FLAGS_CPU_NEC -O4 -finline) # CMake doesn't detect this so it's meant to be chosen by register_flag_optional(ARCH)
-
 register_flag_optional(CMAKE_CXX_COMPILER
-        "Any CXX compiler that supports OpenMP as per CMake detection (and offloading if enabled with `OFFLOAD`)"
+        "Any CXX compiler that supports OpenACC as per CMake detection"
         "c++")
 
-register_flag_optional(ARCH
-        "This overrides CMake's CMAKE_SYSTEM_PROCESSOR detection which uses (uname -p), this is mainly for use with
-         specialised accelerators only and not to be confused with offload which is is mutually exclusive with this.
-         Supported values are:
-          - NEC"
+register_flag_optional(TARGET_DEVICE
+        "[PGI/NVHPC only] This sets the `-target` flag, possible values are:
+             gpu       - Globally set the target device to an NVIDIA GPU
+             multicore - Globally set the target device to the host CPU
+         Refer to `nvc++ --help` for the full list"
         "")
 
-register_flag_optional(OFFLOAD
-        "Whether to use OpenMP offload, the format is <VENDOR:ARCH?>|ON|OFF.
-        We support a small set of known offload flags for clang, gcc, and icpx.
-        However, as offload support is rapidly evolving, we recommend you directly supply them via OFFLOAD_FLAGS.
-        For example:
-          * OFFLOAD=NVIDIA:sm_60
-          * OFFLOAD=AMD:gfx906
-          * OFFLOAD=INTEL
-          * OFFLOAD=ON OFFLOAD_FLAGS=..."
-        OFF)
 
-register_flag_optional(OFFLOAD_FLAGS
-        "If OFFLOAD is enabled, this *overrides* the default offload flags"
+register_flag_optional(CUDA_ARCH
+        "[PGI/NVHPC only] Only applicable if `TARGET_DEVICE` is set to `gpu`.
+         Nvidia architecture in ccXY format, for example, sm_70 becomes cc70, will be passed in via `-gpu=` (e.g `cc70`)
+         Possible values are:
+             cc35  - Compile for compute capability 3.5
+             cc50  - Compile for compute capability 5.0
+             cc60  - Compile for compute capability 6.0
+             cc62  - Compile for compute capability 6.2
+             cc70  - Compile for compute capability 7.0
+             cc72  - Compile for compute capability 7.2
+             cc75  - Compile for compute capability 7.5
+             cc80  - Compile for compute capability 8.0
+             ccall - Compile for all supported compute capabilities
+         Refer to `nvc++ --help` for the full list"
         "")
 
-register_flag_optional(OFFLOAD_APPEND_LINK_FLAG
-        "If enabled, this appends all resolved offload flags (OFFLOAD=<vendor:arch> or directly from OFFLOAD_FLAGS) to the link flags.
-        This is required for most offload implementations so that offload libraries can linked correctly."
-        ON)
-
+register_flag_optional(TARGET_PROCESSOR
+        "[PGI/NVHPC only] This sets the `-tp` (target processor) flag, possible values are:
+             px          - Generic x86 Processor
+             bulldozer   - AMD Bulldozer processor
+             piledriver  - AMD Piledriver processor
+             zen         - AMD Zen architecture (Epyc, Ryzen)
+             zen2        - AMD Zen 2 architecture (Ryzen 2)
+             sandybridge - Intel SandyBridge processor
+             haswell     - Intel Haswell processor
+             knl         - Intel Knights Landing processor
+             skylake     - Intel Skylake Xeon processor
+             host        - Link native version of HPC SDK cpu math library
+             native      - Alias for -tp host
+        Refer to `nvc++ --help` for the full list"
+        "")
 
 macro(setup)
-    find_package(OpenMP REQUIRED)
-    register_link_library(OpenMP::OpenMP_CXX) # TeaLeaf OpenMP kernels are in C, not CXX
-    set(CMAKE_CXX_STANDARD 17)
+    find_package(OpenACC REQUIRED)
 
-    string(TOUPPER ${CMAKE_CXX_COMPILER_ID} COMPILER)
-    if (NOT ARCH)
-        string(TOUPPER ${CMAKE_SYSTEM_PROCESSOR} ARCH)
-    else ()
-        message(STATUS "Using custom arch: ${ARCH}")
-    endif ()
+    if(${CMAKE_VERSION} VERSION_LESS "3.16.0")
+        # CMake didn't really implement ACC as a target before 3.16, so we append them manually
+        separate_arguments(OpenACC_CXX_FLAGS)
+        register_append_cxx_flags(ANY ${OpenACC_CXX_FLAGS})
+        register_append_link_flags(${OpenACC_CXX_FLAGS})
+    else()
+        register_link_library(OpenACC::OpenACC_CXX)
+    endif()
 
 
-    if (("${OFFLOAD}" STREQUAL OFF) OR (NOT DEFINED OFFLOAD))
-        # no offload
+    # XXX NVHPC is really new so older Cmake thinks it's PGI, which is true
+    if ((CMAKE_CXX_COMPILER_ID STREQUAL PGI) OR (CMAKE_CXX_COMPILER_ID STREQUAL NVHPC))
 
-        # resolve the CPU specific flags
-        # starting with ${COMPILER_VENDOR}_${PLATFORM_ARCH}, then try ${COMPILER_VENDOR}, and then give up
-        register_append_compiler_and_arch_specific_cxx_flags(
-                OMP_FLAGS_CPU
-                ${COMPILER}
-                ${ARCH}
-        )
+        if (TARGET_DEVICE)
+            register_append_cxx_flags(ANY -target=${TARGET_DEVICE})
+        endif ()
 
-        register_append_compiler_and_arch_specific_link_flags(
-                OMP_LINK_FLAGS_CPU
-                ${COMPILER}
-                ${ARCH}
-        )
+        if (CUDA_ARCH)
+            register_append_cxx_flags(ANY -gpu=${CUDA_ARCH})
+        endif ()
 
-    elseif ("${OFFLOAD}" STREQUAL ON)
-        #  offload but with custom flags
-        register_definitions(OMP_TARGET DIFFUSE_OVERLOAD)
-        separate_arguments(OFFLOAD_FLAGS)
-        set(OMP_FLAGS ${OFFLOAD_FLAGS})
-    elseif ((DEFINED OFFLOAD) AND OFFLOAD_FLAGS)
-        # offload but OFFLOAD_FLAGS overrides
-        register_definitions(OMP_TARGET DIFFUSE_OVERLOAD)
-        separate_arguments(OFFLOAD_FLAGS)
-        list(OMP_FLAGS APPEND ${OFFLOAD_FLAGS})
-    else ()
-        register_definitions(OMP_TARGET DIFFUSE_OVERLOAD)
-
-        # handle the vendor:arch value
-        string(REPLACE ":" ";" OFFLOAD_TUPLE "${OFFLOAD}")
-
-        list(LENGTH OFFLOAD_TUPLE LEN)
-        if (LEN EQUAL 1)
-            #  offload with <vendor> tuple
-            list(GET OFFLOAD_TUPLE 0 OFFLOAD_VENDOR)
-            # append OMP_FLAGS_OFFLOAD_<vendor> if  exists
-            list(APPEND OMP_FLAGS ${OMP_FLAGS_OFFLOAD_${OFFLOAD_VENDOR}})
-
-        elseif (LEN EQUAL 2)
-            #  offload with <vendor:arch> tuple
-            list(GET OFFLOAD_TUPLE 0 OFFLOAD_VENDOR)
-            list(GET OFFLOAD_TUPLE 1 OFFLOAD_ARCH)
-
-            # append OMP_FLAGS_OFFLOAD_<compiler>_<vendor> if exists
-            list(APPEND OMP_FLAGS ${OMP_FLAGS_OFFLOAD_${COMPILER}_${OFFLOAD_VENDOR}})
-            # append offload arch if OMP_FLAGS_OFFLOAD_<compiler>_ARCH_FLAG if exists
-            if (DEFINED OMP_FLAGS_OFFLOAD_${COMPILER}_ARCH_FLAG)
-                list(APPEND OMP_FLAGS
-                        "${OMP_FLAGS_OFFLOAD_${COMPILER}_ARCH_FLAG}${OFFLOAD_ARCH}")
-            endif ()
-        else ()
-            message(FATAL_ERROR "Unrecognised OFFLOAD format: `${OFFLOAD}`, consider directly using OFFLOAD_FLAGS")
+        if (TARGET_PROCESSOR)
+            register_append_cxx_flags(ANY -tp=${TARGET_PROCESSOR})
         endif ()
 
     endif ()
 
-
-    message(STATUS "OMP CXX  flags : ${OMP_FLAGS}")
-    message(STATUS "OMP Link flags : ${OMP_LINK_FLAGS}")
-    # propagate flags to linker so that it links with the offload stuff as well
-    register_append_cxx_flags(ANY ${OMP_FLAGS})
-    if (OFFLOAD_APPEND_LINK_FLAG)
-        register_append_link_flags(${OMP_FLAGS})
-    endif ()
 endmacro()
 

--- a/src/acc/pack_kernel.cpp
+++ b/src/acc/pack_kernel.cpp
@@ -1,0 +1,327 @@
+/*
+ Crown Copyright 2012 AWE.
+
+ This file is part of CloverLeaf.
+
+ CloverLeaf is free software: you can redistribute it and/or modify it under
+ the terms of the GNU General Public License as published by the
+ Free Software Foundation, either version 3 of the License, or (at your option)
+ any later version.
+
+ CloverLeaf is distributed in the hope that it will be useful, but
+ WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ details.
+
+ You should have received a copy of the GNU General Public License along with
+ CloverLeaf. If not, see http://www.gnu.org/licenses/.
+ */
+
+//  @brief Fortran mpi buffer packing kernel
+//  @author Wayne Gaudin
+//  @details Packs/unpacks mpi send and receive buffers
+
+#include "pack_kernel.h"
+#include "context.h"
+
+void clover_pack_message_left(global_variables &globals, int x_min, int x_max, int y_min, int y_max, clover::Buffer2D<double> &field_buffer,
+                              clover::Buffer1D<double> &left_snd_buffer, int cell_data, int vertex_data, int x_face_data, int y_face_data,
+                              int depth, int field_type, int buffer_offset) {
+
+  // Pack
+
+  int x_inc = 0, y_inc = 0;
+
+  // These array modifications still need to be added on, plus the donor data location changes as in update_halo
+  if (field_type == cell_data) {
+    x_inc = 0;
+    y_inc = 0;
+  }
+  if (field_type == vertex_data) {
+    x_inc = 1;
+    y_inc = 1;
+  }
+  if (field_type == x_face_data) {
+    x_inc = 1;
+    y_inc = 0;
+  }
+  if (field_type == y_face_data) {
+    x_inc = 0;
+    y_inc = 1;
+  }
+
+  // DO k=y_min-depth,y_max+y_inc+depth
+
+  double *left_snd = left_snd_buffer.data;
+  double *field = field_buffer.data;
+  const size_t field_sizex = field_buffer.nX();
+#pragma omp target teams distribute parallel for simd clover_use_target(globals.context.use_target)
+  for (int k = (y_min - depth + 1); k < (y_max + y_inc + depth + 2); k++) {
+    for (int j = 0; j < depth; ++j) {
+      int index = buffer_offset + j + k * depth;
+      left_snd[index] = field[(x_min + x_inc - 1 + j + 2) + (k)*field_sizex];
+    }
+  }
+}
+
+void clover_unpack_message_left(global_variables &globals, int x_min, int x_max, int y_min, int y_max,
+                                clover::Buffer2D<double> &field_buffer, clover::Buffer1D<double> &left_rcv_buffer, int cell_data,
+                                int vertex_data, int x_face_data, int y_face_data, int depth, int field_type, int buffer_offset) {
+
+  // Upnack
+
+  int y_inc = 0;
+
+  // These array modifications still need to be added on, plus the donor data location changes as in update_halo
+  if (field_type == cell_data) {
+    y_inc = 0;
+  }
+  if (field_type == vertex_data) {
+    y_inc = 1;
+  }
+  if (field_type == x_face_data) {
+    y_inc = 0;
+  }
+  if (field_type == y_face_data) {
+    y_inc = 1;
+  }
+
+  // DO k=y_min-depth,y_max+y_inc+depth
+
+  double *field = field_buffer.data;
+  const size_t field_sizex = field_buffer.nX();
+  double *left_rcv = left_rcv_buffer.data;
+#pragma omp target teams distribute parallel for simd clover_use_target(globals.context.use_target)
+  for (int k = (y_min - depth + 1); k < (y_max + y_inc + depth + 2); k++) {
+    for (int j = 0; j < depth; ++j) {
+      int index = buffer_offset + j + k * depth;
+      field[(x_min - j) + (k)*field_sizex] = left_rcv[index];
+    }
+  }
+}
+
+void clover_pack_message_right(global_variables &globals, int x_min, int x_max, int y_min, int y_max,
+                               clover::Buffer2D<double> &field_buffer, clover::Buffer1D<double> &right_snd_buffer, int cell_data,
+                               int vertex_data, int x_face_data, int y_face_data, int depth, int field_type, int buffer_offset) {
+
+  // Pack
+
+  int y_inc = 0;
+
+  // These array modifications still need to be added on, plus the donor data location changes as in update_halo
+  if (field_type == cell_data) {
+    y_inc = 0;
+  }
+  if (field_type == vertex_data) {
+    y_inc = 1;
+  }
+  if (field_type == x_face_data) {
+    y_inc = 0;
+  }
+  if (field_type == y_face_data) {
+    y_inc = 1;
+  }
+
+  // DO k=y_min-depth,y_max+y_inc+depth
+  double *right_snd = right_snd_buffer.data;
+  double *field = field_buffer.data;
+  const size_t field_sizex = field_buffer.nX();
+#pragma omp target teams distribute parallel for simd clover_use_target(globals.context.use_target)
+  for (int k = (y_min - depth + 1); k < (y_max + y_inc + depth + 2); k++) {
+    for (int j = 0; j < depth; ++j) {
+      int index = buffer_offset + j + k * depth;
+      right_snd[index] = field[(x_max + 1 - j) + (k)*field_sizex];
+    }
+  }
+}
+
+void clover_unpack_message_right(global_variables &globals, int x_min, int x_max, int y_min, int y_max,
+                                 clover::Buffer2D<double> &field_buffer, clover::Buffer1D<double> &right_rcv_buffer, int cell_data,
+                                 int vertex_data, int x_face_data, int y_face_data, int depth, int field_type, int buffer_offset) {
+
+  // Upnack
+
+  int x_inc = 0, y_inc = 0;
+
+  // These array modifications still need to be added on, plus the donor data location changes as in update_halo
+  if (field_type == cell_data) {
+    x_inc = 0;
+    y_inc = 0;
+  }
+  if (field_type == vertex_data) {
+    x_inc = 1;
+    y_inc = 1;
+  }
+  if (field_type == x_face_data) {
+    x_inc = 1;
+    y_inc = 0;
+  }
+  if (field_type == y_face_data) {
+    x_inc = 0;
+    y_inc = 1;
+  }
+
+  // DO k=y_min-depth,y_max+y_inc+depth
+  double *right_rcv = right_rcv_buffer.data;
+  double *field = field_buffer.data;
+  const size_t field_sizex = field_buffer.nX();
+#pragma omp target teams distribute parallel for simd clover_use_target(globals.context.use_target)
+  for (int k = (y_min - depth + 1); k < (y_max + y_inc + depth + 2); k++) {
+    for (int j = 0; j < depth; ++j) {
+      int index = buffer_offset + j + k * depth;
+      field[(x_max + x_inc + j + 2) + (k)*field_sizex] = right_rcv[index];
+    }
+  }
+}
+
+void clover_pack_message_top(global_variables &globals, int x_min, int x_max, int y_min, int y_max, clover::Buffer2D<double> &field_buffer,
+                             clover::Buffer1D<double> &top_snd_buffer, int cell_data, int vertex_data, int x_face_data, int y_face_data,
+                             int depth, int field_type, int buffer_offset) {
+
+  // Pack
+
+  int x_inc = 0;
+
+  // These array modifications still need to be added on, plus the donor data location changes as in update_halo
+  if (field_type == cell_data) {
+    x_inc = 0;
+  }
+  if (field_type == vertex_data) {
+    x_inc = 1;
+  }
+  if (field_type == x_face_data) {
+    x_inc = 1;
+  }
+  if (field_type == y_face_data) {
+    x_inc = 0;
+  }
+
+  for (int k = 0; k < depth; ++k) {
+    // DO j=x_min-depth,x_max+x_inc+depth
+
+    double *top_snd = top_snd_buffer.data;
+    double *field = field_buffer.data;
+    const size_t field_sizex = field_buffer.nX();
+#pragma omp target teams distribute parallel for simd clover_use_target(globals.context.use_target)
+    for (int j = (x_min - depth + 1); j < (x_max + x_inc + depth + 2); j++) {
+      int index = buffer_offset + k + j * depth;
+      top_snd[index] = field[j + (y_max + 1 - k) * field_sizex];
+    }
+  }
+}
+
+void clover_unpack_message_top(global_variables &globals, int x_min, int x_max, int y_min, int y_max,
+                               clover::Buffer2D<double> &field_buffer, clover::Buffer1D<double> &top_rcv_buffer, int cell_data,
+                               int vertex_data, int x_face_data, int y_face_data, int depth, int field_type, int buffer_offset) {
+
+  // Unpack
+
+  int x_inc = 0, y_inc = 0;
+
+  // These array modifications still need to be added on, plus the donor data location changes as in update_halo
+  if (field_type == cell_data) {
+    x_inc = 0;
+    y_inc = 0;
+  }
+  if (field_type == vertex_data) {
+    x_inc = 1;
+    y_inc = 1;
+  }
+  if (field_type == x_face_data) {
+    x_inc = 1;
+    y_inc = 0;
+  }
+  if (field_type == y_face_data) {
+    x_inc = 0;
+    y_inc = 1;
+  }
+
+  for (int k = 0; k < depth; ++k) {
+    // DO j=x_min-depth,x_max+x_inc+depth
+
+    double *field = field_buffer.data;
+    const size_t field_sizex = field_buffer.nX();
+    double *top_rcv = top_rcv_buffer.data;
+#pragma omp target teams distribute parallel for simd clover_use_target(globals.context.use_target)
+    for (int j = (x_min - depth + 1); j < (x_max + x_inc + depth + 2); j++) {
+      int index = buffer_offset + k + j * depth;
+      field[j + (y_max + y_inc + k + 2) * field_sizex] = top_rcv[index];
+    }
+  }
+}
+
+void clover_pack_message_bottom(global_variables &globals, int x_min, int x_max, int y_min, int y_max,
+                                clover::Buffer2D<double> &field_buffer, clover::Buffer1D<double> &bottom_snd_buffer, int cell_data,
+                                int vertex_data, int x_face_data, int y_face_data, int depth, int field_type, int buffer_offset) {
+
+  // Pack
+
+  int x_inc = 0, y_inc = 0;
+
+  // These array modifications still need to be added on, plus the donor data location changes as in update_halo
+  if (field_type == cell_data) {
+    x_inc = 0;
+    y_inc = 0;
+  }
+  if (field_type == vertex_data) {
+    x_inc = 1;
+    y_inc = 1;
+  }
+  if (field_type == x_face_data) {
+    x_inc = 1;
+    y_inc = 0;
+  }
+  if (field_type == y_face_data) {
+    x_inc = 0;
+    y_inc = 1;
+  }
+
+  for (int k = 0; k < depth; ++k) {
+    // DO j=x_min-depth,x_max+x_inc+depth
+
+    double *bottom_snd = bottom_snd_buffer.data;
+    double *field = field_buffer.data;
+    const size_t field_sizex = field_buffer.nX();
+#pragma omp target teams distribute parallel for simd clover_use_target(globals.context.use_target)
+    for (int j = (x_min - depth + 1); j < (x_max + x_inc + depth + 2); j++) {
+      int index = buffer_offset + k + j * depth;
+      bottom_snd[index] = field[j + (y_min + y_inc - 1 + k + 2) * field_sizex];
+    }
+  }
+}
+
+void clover_unpack_message_bottom(global_variables &globals, int x_min, int x_max, int y_min, int y_max,
+                                  clover::Buffer2D<double> &field_buffer, clover::Buffer1D<double> &bottom_rcv_buffer, int cell_data,
+                                  int vertex_data, int x_face_data, int y_face_data, int depth, int field_type, int buffer_offset) {
+
+  // Unpack
+
+  int x_inc = 0;
+
+  // These array modifications still need to be added on, plus the donor data location changes as in update_halo
+  if (field_type == cell_data) {
+    x_inc = 0;
+  }
+  if (field_type == vertex_data) {
+    x_inc = 1;
+  }
+  if (field_type == x_face_data) {
+    x_inc = 1;
+  }
+  if (field_type == y_face_data) {
+    x_inc = 0;
+  }
+
+  for (int k = 0; k < depth; ++k) {
+    // DO j=x_min-depth,x_max+x_inc+depth
+
+    double *field = field_buffer.data;
+    const size_t field_sizex = field_buffer.nX();
+    double *bottom_rcv = bottom_rcv_buffer.data;
+#pragma omp target teams distribute parallel for simd clover_use_target(globals.context.use_target)
+    for (int j = (x_min - depth + 1); j < (x_max + x_inc + depth + 2); j++) {
+      int index = buffer_offset + k + j * depth;
+      field[j + (y_min - k) * field_sizex] = bottom_rcv[index];
+    }
+  }
+}

--- a/src/acc/pack_kernel.cpp
+++ b/src/acc/pack_kernel.cpp
@@ -55,7 +55,9 @@ void clover_pack_message_left(global_variables &globals, int x_min, int x_max, i
   double *left_snd = left_snd_buffer.data;
   double *field = field_buffer.data;
   const size_t field_sizex = field_buffer.nX();
-#pragma omp target teams distribute parallel for simd clover_use_target(globals.context.use_target)
+/* TODO NVHPC Compiler is also saying that it can't parallelize this loop
+ * Can force if the calc of index is unique */
+#pragma acc parallel loop gang worker vector default(present) clover_use_target(globals.context.use_target)
   for (int k = (y_min - depth + 1); k < (y_max + y_inc + depth + 2); k++) {
     for (int j = 0; j < depth; ++j) {
       int index = buffer_offset + j + k * depth;
@@ -91,7 +93,7 @@ void clover_unpack_message_left(global_variables &globals, int x_min, int x_max,
   double *field = field_buffer.data;
   const size_t field_sizex = field_buffer.nX();
   double *left_rcv = left_rcv_buffer.data;
-#pragma omp target teams distribute parallel for simd clover_use_target(globals.context.use_target)
+#pragma acc parallel loop gang worker vector default(present) clover_use_target(globals.context.use_target)
   for (int k = (y_min - depth + 1); k < (y_max + y_inc + depth + 2); k++) {
     for (int j = 0; j < depth; ++j) {
       int index = buffer_offset + j + k * depth;
@@ -126,7 +128,7 @@ void clover_pack_message_right(global_variables &globals, int x_min, int x_max, 
   double *right_snd = right_snd_buffer.data;
   double *field = field_buffer.data;
   const size_t field_sizex = field_buffer.nX();
-#pragma omp target teams distribute parallel for simd clover_use_target(globals.context.use_target)
+#pragma acc parallel loop gang worker vector default(present) clover_use_target(globals.context.use_target)
   for (int k = (y_min - depth + 1); k < (y_max + y_inc + depth + 2); k++) {
     for (int j = 0; j < depth; ++j) {
       int index = buffer_offset + j + k * depth;
@@ -165,7 +167,7 @@ void clover_unpack_message_right(global_variables &globals, int x_min, int x_max
   double *right_rcv = right_rcv_buffer.data;
   double *field = field_buffer.data;
   const size_t field_sizex = field_buffer.nX();
-#pragma omp target teams distribute parallel for simd clover_use_target(globals.context.use_target)
+#pragma acc parallel loop gang worker vector default(present) clover_use_target(globals.context.use_target)
   for (int k = (y_min - depth + 1); k < (y_max + y_inc + depth + 2); k++) {
     for (int j = 0; j < depth; ++j) {
       int index = buffer_offset + j + k * depth;
@@ -202,7 +204,7 @@ void clover_pack_message_top(global_variables &globals, int x_min, int x_max, in
     double *top_snd = top_snd_buffer.data;
     double *field = field_buffer.data;
     const size_t field_sizex = field_buffer.nX();
-#pragma omp target teams distribute parallel for simd clover_use_target(globals.context.use_target)
+#pragma acc parallel loop gang worker vector default(present) clover_use_target(globals.context.use_target)
     for (int j = (x_min - depth + 1); j < (x_max + x_inc + depth + 2); j++) {
       int index = buffer_offset + k + j * depth;
       top_snd[index] = field[j + (y_max + 1 - k) * field_sizex];
@@ -242,7 +244,7 @@ void clover_unpack_message_top(global_variables &globals, int x_min, int x_max, 
     double *field = field_buffer.data;
     const size_t field_sizex = field_buffer.nX();
     double *top_rcv = top_rcv_buffer.data;
-#pragma omp target teams distribute parallel for simd clover_use_target(globals.context.use_target)
+#pragma acc parallel loop gang worker vector default(present) clover_use_target(globals.context.use_target)
     for (int j = (x_min - depth + 1); j < (x_max + x_inc + depth + 2); j++) {
       int index = buffer_offset + k + j * depth;
       field[j + (y_max + y_inc + k + 2) * field_sizex] = top_rcv[index];
@@ -282,7 +284,7 @@ void clover_pack_message_bottom(global_variables &globals, int x_min, int x_max,
     double *bottom_snd = bottom_snd_buffer.data;
     double *field = field_buffer.data;
     const size_t field_sizex = field_buffer.nX();
-#pragma omp target teams distribute parallel for simd clover_use_target(globals.context.use_target)
+#pragma acc parallel loop gang worker vector default(present) clover_use_target(globals.context.use_target)
     for (int j = (x_min - depth + 1); j < (x_max + x_inc + depth + 2); j++) {
       int index = buffer_offset + k + j * depth;
       bottom_snd[index] = field[j + (y_min + y_inc - 1 + k + 2) * field_sizex];
@@ -318,7 +320,7 @@ void clover_unpack_message_bottom(global_variables &globals, int x_min, int x_ma
     double *field = field_buffer.data;
     const size_t field_sizex = field_buffer.nX();
     double *bottom_rcv = bottom_rcv_buffer.data;
-#pragma omp target teams distribute parallel for simd clover_use_target(globals.context.use_target)
+#pragma acc parallel loop gang worker vector default(present) clover_use_target(globals.context.use_target)
     for (int j = (x_min - depth + 1); j < (x_max + x_inc + depth + 2); j++) {
       int index = buffer_offset + k + j * depth;
       field[j + (y_min - k) * field_sizex] = bottom_rcv[index];

--- a/src/acc/pack_kernel.cpp
+++ b/src/acc/pack_kernel.cpp
@@ -55,8 +55,6 @@ void clover_pack_message_left(global_variables &globals, int x_min, int x_max, i
   double *left_snd = left_snd_buffer.data;
   double *field = field_buffer.data;
   const size_t field_sizex = field_buffer.nX();
-/* TODO NVHPC Compiler is also saying that it can't parallelize this loop
- * Can force if the calc of index is unique */
 #pragma acc parallel loop gang worker vector default(present) clover_use_target(globals.context.use_target)
   for (int k = (y_min - depth + 1); k < (y_max + y_inc + depth + 2); k++) {
     for (int j = 0; j < depth; ++j) {

--- a/src/acc/pack_kernel.cpp
+++ b/src/acc/pack_kernel.cpp
@@ -55,7 +55,8 @@ void clover_pack_message_left(global_variables &globals, int x_min, int x_max, i
   double *left_snd = left_snd_buffer.data;
   double *field = field_buffer.data;
   const size_t field_sizex = field_buffer.nX();
-#pragma acc parallel loop gang worker vector default(present) clover_use_target(globals.context.use_target)
+#pragma acc parallel loop gang worker vector clover_use_target(globals.context.use_target) \
+  present(left_snd[ : left_snd_buffer.N()], field[ : field_buffer.N()])
   for (int k = (y_min - depth + 1); k < (y_max + y_inc + depth + 2); k++) {
     for (int j = 0; j < depth; ++j) {
       int index = buffer_offset + j + k * depth;
@@ -91,7 +92,8 @@ void clover_unpack_message_left(global_variables &globals, int x_min, int x_max,
   double *field = field_buffer.data;
   const size_t field_sizex = field_buffer.nX();
   double *left_rcv = left_rcv_buffer.data;
-#pragma acc parallel loop gang worker vector default(present) clover_use_target(globals.context.use_target)
+#pragma acc parallel loop gang worker vector clover_use_target(globals.context.use_target) \
+  present(left_rcv[ : left_rcv_buffer.N()], field[ : field_buffer.N()])
   for (int k = (y_min - depth + 1); k < (y_max + y_inc + depth + 2); k++) {
     for (int j = 0; j < depth; ++j) {
       int index = buffer_offset + j + k * depth;
@@ -126,7 +128,8 @@ void clover_pack_message_right(global_variables &globals, int x_min, int x_max, 
   double *right_snd = right_snd_buffer.data;
   double *field = field_buffer.data;
   const size_t field_sizex = field_buffer.nX();
-#pragma acc parallel loop gang worker vector default(present) clover_use_target(globals.context.use_target)
+#pragma acc parallel loop gang worker vector clover_use_target(globals.context.use_target) \
+  present(right_snd[ : right_snd_buffer.N()], field[ : field_buffer.N()])
   for (int k = (y_min - depth + 1); k < (y_max + y_inc + depth + 2); k++) {
     for (int j = 0; j < depth; ++j) {
       int index = buffer_offset + j + k * depth;
@@ -165,7 +168,8 @@ void clover_unpack_message_right(global_variables &globals, int x_min, int x_max
   double *right_rcv = right_rcv_buffer.data;
   double *field = field_buffer.data;
   const size_t field_sizex = field_buffer.nX();
-#pragma acc parallel loop gang worker vector default(present) clover_use_target(globals.context.use_target)
+#pragma acc parallel loop gang worker vector clover_use_target(globals.context.use_target) \
+  present(right_rcv[ : right_rcv_buffer.N()], field[ : field_buffer.N()])
   for (int k = (y_min - depth + 1); k < (y_max + y_inc + depth + 2); k++) {
     for (int j = 0; j < depth; ++j) {
       int index = buffer_offset + j + k * depth;
@@ -202,7 +206,8 @@ void clover_pack_message_top(global_variables &globals, int x_min, int x_max, in
     double *top_snd = top_snd_buffer.data;
     double *field = field_buffer.data;
     const size_t field_sizex = field_buffer.nX();
-#pragma acc parallel loop gang worker vector default(present) clover_use_target(globals.context.use_target)
+#pragma acc parallel loop gang worker vector clover_use_target(globals.context.use_target) \
+  present(top_snd[ : top_snd_buffer.N()], field[ : field_buffer.N()])
     for (int j = (x_min - depth + 1); j < (x_max + x_inc + depth + 2); j++) {
       int index = buffer_offset + k + j * depth;
       top_snd[index] = field[j + (y_max + 1 - k) * field_sizex];
@@ -242,7 +247,8 @@ void clover_unpack_message_top(global_variables &globals, int x_min, int x_max, 
     double *field = field_buffer.data;
     const size_t field_sizex = field_buffer.nX();
     double *top_rcv = top_rcv_buffer.data;
-#pragma acc parallel loop gang worker vector default(present) clover_use_target(globals.context.use_target)
+#pragma acc parallel loop gang worker vector clover_use_target(globals.context.use_target) \
+  present(top_rcv[ : top_rcv_buffer.N()], field[ : field_buffer.N()])
     for (int j = (x_min - depth + 1); j < (x_max + x_inc + depth + 2); j++) {
       int index = buffer_offset + k + j * depth;
       field[j + (y_max + y_inc + k + 2) * field_sizex] = top_rcv[index];
@@ -282,7 +288,8 @@ void clover_pack_message_bottom(global_variables &globals, int x_min, int x_max,
     double *bottom_snd = bottom_snd_buffer.data;
     double *field = field_buffer.data;
     const size_t field_sizex = field_buffer.nX();
-#pragma acc parallel loop gang worker vector default(present) clover_use_target(globals.context.use_target)
+#pragma acc parallel loop gang worker vector clover_use_target(globals.context.use_target) \
+  present(bottom_snd[ : bottom_snd_buffer.N()], field[ : field_buffer.N()])
     for (int j = (x_min - depth + 1); j < (x_max + x_inc + depth + 2); j++) {
       int index = buffer_offset + k + j * depth;
       bottom_snd[index] = field[j + (y_min + y_inc - 1 + k + 2) * field_sizex];
@@ -318,7 +325,8 @@ void clover_unpack_message_bottom(global_variables &globals, int x_min, int x_ma
     double *field = field_buffer.data;
     const size_t field_sizex = field_buffer.nX();
     double *bottom_rcv = bottom_rcv_buffer.data;
-#pragma acc parallel loop gang worker vector default(present) clover_use_target(globals.context.use_target)
+#pragma acc parallel loop gang worker vector clover_use_target(globals.context.use_target) \
+  present(bottom_rcv[ : bottom_rcv_buffer.N()], field[ : field_buffer.N()])
     for (int j = (x_min - depth + 1); j < (x_max + x_inc + depth + 2); j++) {
       int index = buffer_offset + k + j * depth;
       field[j + (y_min - k) * field_sizex] = bottom_rcv[index];

--- a/src/acc/reset_field.cpp
+++ b/src/acc/reset_field.cpp
@@ -1,0 +1,85 @@
+/*
+ Crown Copyright 2012 AWE.
+
+ This file is part of CloverLeaf.
+
+ CloverLeaf is free software: you can redistribute it and/or modify it under
+ the terms of the GNU General Public License as published by the
+ Free Software Foundation, either version 3 of the License, or (at your option)
+ any later version.
+
+ CloverLeaf is distributed in the hope that it will be useful, but
+ WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ details.
+
+ You should have received a copy of the GNU General Public License along with
+ CloverLeaf. If not, see http://www.gnu.org/licenses/.
+ */
+
+#include "reset_field.h"
+#include "timer.h"
+
+//  @brief Fortran reset field kernel.
+//  @author Wayne Gaudin
+//  @details Copies all of the final end of step filed data to the begining of
+//  step data, ready for the next timestep.
+void reset_field_kernel(bool use_target, int x_min, int x_max, int y_min, int y_max, field_type &field) {
+
+  // DO k=y_min,y_max
+  //   DO j=x_min,x_max
+  const int base_stride = field.base_stride;
+  double *density0 = field.density0.data;
+  double *density1 = field.density1.data;
+  double *energy0 = field.energy0.data;
+  double *energy1 = field.energy1.data;
+
+#pragma omp target teams distribute parallel for simd collapse(2) clover_use_target(use_target)
+  for (int j = (y_min + 1); j < (y_max + 2); j++) {
+    for (int i = (x_min + 1); i < (x_max + 2); i++) {
+      density0[i + j * base_stride] = density1[i + j * base_stride];
+      energy0[i + j * base_stride] = energy1[i + j * base_stride];
+    }
+  }
+
+  // DO k=y_min,y_max+1
+  //   DO j=x_min,x_max+1
+  const int vels_wk_stride = field.vels_wk_stride;
+  double *xvel0 = field.xvel0.data;
+  double *xvel1 = field.xvel1.data;
+  double *yvel0 = field.yvel0.data;
+  double *yvel1 = field.yvel1.data;
+
+#pragma omp target teams distribute parallel for simd collapse(2) clover_use_target(use_target)
+  for (int j = (y_min + 1); j < (y_max + 1 + 2); j++) {
+    for (int i = (x_min + 1); i < (x_max + 1 + 2); i++) {
+      xvel0[i + j * vels_wk_stride] = xvel1[i + j * vels_wk_stride];
+      yvel0[i + j * vels_wk_stride] = yvel1[i + j * vels_wk_stride];
+    }
+  }
+}
+
+//  @brief Reset field driver
+//  @author Wayne Gaudin
+//  @details Invokes the user specified field reset kernel.
+void reset_field(global_variables &globals) {
+
+  double kernel_time = 0;
+  if (globals.profiler_on) kernel_time = timer();
+
+#if SYNC_BUFFERS
+  globals.hostToDevice();
+#endif
+
+  for (int tile = 0; tile < globals.config.tiles_per_chunk; ++tile) {
+
+    tile_type &t = globals.chunk.tiles[tile];
+    reset_field_kernel(globals.context.use_target, t.info.t_xmin, t.info.t_xmax, t.info.t_ymin, t.info.t_ymax, t.field);
+  }
+
+#if SYNC_BUFFERS
+  globals.deviceToHost();
+#endif
+
+  if (globals.profiler_on) globals.profiler.reset += timer() - kernel_time;
+}

--- a/src/acc/reset_field.cpp
+++ b/src/acc/reset_field.cpp
@@ -34,7 +34,9 @@ void reset_field_kernel(bool use_target, int x_min, int x_max, int y_min, int y_
   double *energy0 = field.energy0.data;
   double *energy1 = field.energy1.data;
 
-#pragma acc parallel loop gang worker vector default(present) collapse(2) clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector collapse(2) clover_use_target(use_target) \
+  present(density0[ : field.density0.N()], density1[ : field.density1.N()],            \
+          energy0[ : field.energy0.N()], energy1[ : field.energy1.N()])
   for (int j = (y_min + 1); j < (y_max + 2); j++) {
     for (int i = (x_min + 1); i < (x_max + 2); i++) {
       density0[i + j * base_stride] = density1[i + j * base_stride];
@@ -50,7 +52,9 @@ void reset_field_kernel(bool use_target, int x_min, int x_max, int y_min, int y_
   double *yvel0 = field.yvel0.data;
   double *yvel1 = field.yvel1.data;
 
-#pragma acc parallel loop gang worker vector default(present) collapse(2) clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector collapse(2) clover_use_target(use_target) \
+  present(xvel0[ : field.xvel0.N()], xvel1[ : field.xvel1.N()],                        \
+          yvel0[ : field.yvel0.N()], yvel1[ : field.yvel1.N()])
   for (int j = (y_min + 1); j < (y_max + 1 + 2); j++) {
     for (int i = (x_min + 1); i < (x_max + 1 + 2); i++) {
       xvel0[i + j * vels_wk_stride] = xvel1[i + j * vels_wk_stride];

--- a/src/acc/reset_field.cpp
+++ b/src/acc/reset_field.cpp
@@ -34,7 +34,7 @@ void reset_field_kernel(bool use_target, int x_min, int x_max, int y_min, int y_
   double *energy0 = field.energy0.data;
   double *energy1 = field.energy1.data;
 
-#pragma omp target teams distribute parallel for simd collapse(2) clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector default(present) collapse(2) clover_use_target(use_target)
   for (int j = (y_min + 1); j < (y_max + 2); j++) {
     for (int i = (x_min + 1); i < (x_max + 2); i++) {
       density0[i + j * base_stride] = density1[i + j * base_stride];
@@ -50,7 +50,7 @@ void reset_field_kernel(bool use_target, int x_min, int x_max, int y_min, int y_
   double *yvel0 = field.yvel0.data;
   double *yvel1 = field.yvel1.data;
 
-#pragma omp target teams distribute parallel for simd collapse(2) clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector default(present) collapse(2) clover_use_target(use_target)
   for (int j = (y_min + 1); j < (y_max + 1 + 2); j++) {
     for (int i = (x_min + 1); i < (x_max + 1 + 2); i++) {
       xvel0[i + j * vels_wk_stride] = xvel1[i + j * vels_wk_stride];

--- a/src/acc/revert.cpp
+++ b/src/acc/revert.cpp
@@ -1,0 +1,64 @@
+/*
+ Crown Copyright 2012 AWE.
+
+ This file is part of CloverLeaf.
+
+ CloverLeaf is free software: you can redistribute it and/or modify it under
+ the terms of the GNU General Public License as published by the
+ Free Software Foundation, either version 3 of the License, or (at your option)
+ any later version.
+
+ CloverLeaf is distributed in the hope that it will be useful, but
+ WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ details.
+
+ You should have received a copy of the GNU General Public License along with
+ CloverLeaf. If not, see http://www.gnu.org/licenses/.
+ */
+
+#include "revert.h"
+
+//  @brief Fortran revert kernel.
+//  @author Wayne Gaudin
+//  @details Takes the half step field data used in the predictor and reverts
+//  it to the start of step data, ready for the corrector.
+//  Note that this does not seem necessary in this proxy-app but should be
+//  left in to remain relevant to the full method.
+void revert_kernel(bool use_target, int x_min, int x_max, int y_min, int y_max, field_type &field) {
+
+  // DO k=y_min,y_max
+  //   DO j=x_min,x_max
+  const int base_stride = field.base_stride;
+  double *density0 = field.density0.data;
+  double *density1 = field.density1.data;
+  double *energy0 = field.energy0.data;
+  double *energy1 = field.energy1.data;
+
+#pragma omp target teams distribute parallel for simd collapse(2) clover_use_target(use_target)
+  for (int j = (y_min + 1); j < (y_max + 2); j++) {
+    for (int i = (x_min + 1); i < (x_max + 2); i++) {
+      density1[i + j * base_stride] = density0[i + j * base_stride];
+      energy1[i + j * base_stride] = energy0[i + j * base_stride];
+    }
+  }
+}
+
+//  @brief Driver routine for the revert kernels.
+//  @author Wayne Gaudin
+//  @details Invokes the user specified revert kernel.
+void revert(global_variables &globals) {
+
+#if SYNC_BUFFERS
+  globals.hostToDevice();
+#endif
+
+  for (int tile = 0; tile < globals.config.tiles_per_chunk; ++tile) {
+    tile_type &t = globals.chunk.tiles[tile];
+    revert_kernel(globals.context.use_target, t.info.t_xmin, t.info.t_xmax, t.info.t_ymin, t.info.t_ymax, t.field);
+  }
+
+#if SYNC_BUFFERS
+  globals.deviceToHost();
+#endif
+}

--- a/src/acc/revert.cpp
+++ b/src/acc/revert.cpp
@@ -35,7 +35,7 @@ void revert_kernel(bool use_target, int x_min, int x_max, int y_min, int y_max, 
   double *energy0 = field.energy0.data;
   double *energy1 = field.energy1.data;
 
-#pragma omp target teams distribute parallel for simd collapse(2) clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector default(present) collapse(2) clover_use_target(use_target)
   for (int j = (y_min + 1); j < (y_max + 2); j++) {
     for (int i = (x_min + 1); i < (x_max + 2); i++) {
       density1[i + j * base_stride] = density0[i + j * base_stride];

--- a/src/acc/revert.cpp
+++ b/src/acc/revert.cpp
@@ -35,7 +35,9 @@ void revert_kernel(bool use_target, int x_min, int x_max, int y_min, int y_max, 
   double *energy0 = field.energy0.data;
   double *energy1 = field.energy1.data;
 
-#pragma acc parallel loop gang worker vector default(present) collapse(2) clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector collapse(2) clover_use_target(use_target) \
+  present(density0[ : field.density0.N()], density1[ : field.density1.N()],            \
+          energy0[ : field.energy0.N()], energy1[ : field.energy1.N()])
   for (int j = (y_min + 1); j < (y_max + 2); j++) {
     for (int i = (x_min + 1); i < (x_max + 2); i++) {
       density1[i + j * base_stride] = density0[i + j * base_stride];

--- a/src/acc/update_halo.cpp
+++ b/src/acc/update_halo.cpp
@@ -1,0 +1,790 @@
+/*
+ Crown Copyright 2012 AWE.
+
+ This file is part of CloverLeaf.
+
+ CloverLeaf is free software: you can redistribute it and/or modify it under
+ the terms of the GNU General Public License as published by the
+ Free Software Foundation, either version 3 of the License, or (at your option)
+ any later version.
+
+ CloverLeaf is distributed in the hope that it will be useful, but
+ WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ details.
+
+ You should have received a copy of the GNU General Public License along with
+ CloverLeaf. If not, see http://www.gnu.org/licenses/.
+ */
+
+#include "update_halo.h"
+#include "comms_kernel.h"
+#include "timer.h"
+#include "update_tile_halo.h"
+
+//   @brief Fortran kernel to update the external halo cells in a chunk.
+//   @author Wayne Gaudin
+//   @details Updates halo cells for the required fields at the required depth
+//   for any halo cells that lie on an external boundary. The location and type
+//   of data governs how this is carried out. External boundaries are always
+//   reflective.
+void update_halo_kernel(bool use_target, int x_min, int x_max, int y_min, int y_max, const std::array<int, 4> &chunk_neighbours,
+                        const std::array<int, 4> &tile_neighbours, field_type &field, const int fields[NUM_FIELDS], int depth) {
+
+  const size_t base_stride = field.base_stride;
+  const size_t vels_wk_stride = field.vels_wk_stride;
+  const size_t flux_x_stride = field.flux_x_stride;
+  const size_t flux_y_stride = field.flux_y_stride;
+
+  //  Update values in external halo cells based on depth and fields requested
+  //  Even though half of these loops look the wrong way around, it should be noted
+  //  that depth is either 1 or 2 so that it is more efficient to always thread
+  //  loop along the mesh edge.
+  if (fields[field_density0] == 1) {
+    if ((chunk_neighbours[chunk_bottom] == external_face) && (tile_neighbours[tile_bottom] == external_tile)) {
+      // DO j=x_min-depth,x_max+depth
+
+      double *density0 = field.density0.data;
+#pragma omp target teams distribute parallel for simd clover_use_target(use_target)
+      for (int j = (x_min - depth + 1); j < (x_max + depth + 2); j++) {
+        for (int k = 0; k < depth; ++k) {
+          density0[j + (1 - k) * base_stride] = density0[j + (2 + k) * base_stride];
+        }
+      }
+    }
+    if ((chunk_neighbours[chunk_top] == external_face) && (tile_neighbours[tile_top] == external_tile)) {
+      // DO j=x_min-depth,x_max+depth
+
+      double *density0 = field.density0.data;
+#pragma omp target teams distribute parallel for simd clover_use_target(use_target)
+      for (int j = (x_min - depth + 1); j < (x_max + depth + 2); j++) {
+        for (int k = 0; k < depth; ++k) {
+          density0[j + (y_max + 2 + k) * base_stride] = density0[j + (y_max + 1 - k) * base_stride];
+        }
+      }
+    }
+    if ((chunk_neighbours[chunk_left] == external_face) && (tile_neighbours[tile_left] == external_tile)) {
+      // DO k=y_min-depth,y_max+depth
+
+      double *density0 = field.density0.data;
+#pragma omp target teams distribute parallel for simd clover_use_target(use_target)
+      for (int k = (y_min - depth + 1); k < (y_max + depth + 2); k++) {
+        for (int j = 0; j < depth; ++j) {
+          density0[(1 - j) + (k)*base_stride] = density0[(2 + j) + (k)*base_stride];
+        }
+      }
+    }
+    if ((chunk_neighbours[chunk_right] == external_face) && (tile_neighbours[tile_right] == external_tile)) {
+      // DO k=y_min-depth,y_max+depth
+
+      double *density0 = field.density0.data;
+#pragma omp target teams distribute parallel for simd clover_use_target(use_target)
+      for (int k = (y_min - depth + 1); k < (y_max + depth + 2); k++) {
+        for (int j = 0; j < depth; ++j) {
+          density0[(x_max + 2 + j) + (k)*base_stride] = density0[(x_max + 1 - j) + (k)*base_stride];
+        }
+      }
+    }
+  }
+
+  if (fields[field_density1] == 1) {
+    if ((chunk_neighbours[chunk_bottom] == external_face) && (tile_neighbours[tile_bottom] == external_tile)) {
+      // DO k=y_min-depth,y_max+depth
+
+      double *density1 = field.density1.data;
+#pragma omp target teams distribute parallel for simd clover_use_target(use_target)
+      for (int j = (x_min - depth + 1); j < (x_max + depth + 2); j++) {
+        for (int k = 0; k < depth; ++k) {
+          density1[j + (1 - k) * base_stride] = density1[j + (2 + k) * base_stride];
+        }
+      }
+    }
+    if ((chunk_neighbours[chunk_top] == external_face) && (tile_neighbours[tile_top] == external_tile)) {
+      // DO j=x_min-depth,x_max+depth
+
+      double *density1 = field.density1.data;
+#pragma omp target teams distribute parallel for simd clover_use_target(use_target)
+      for (int j = (x_min - depth + 1); j < (x_max + depth + 2); j++) {
+        for (int k = 0; k < depth; ++k) {
+          density1[j + (y_max + 2 + k) * base_stride] = density1[j + (y_max + 1 - k) * base_stride];
+        }
+      }
+    }
+    if ((chunk_neighbours[chunk_left] == external_face) && (tile_neighbours[tile_left] == external_tile)) {
+      // DO k=y_min-depth,y_max+depth
+
+      double *density1 = field.density1.data;
+#pragma omp target teams distribute parallel for simd clover_use_target(use_target)
+      for (int k = (y_min - depth + 1); k < (y_max + depth + 2); k++) {
+        for (int j = 0; j < depth; ++j) {
+          density1[(1 - j) + (k)*base_stride] = density1[(2 + j) + (k)*base_stride];
+        }
+      }
+    }
+    if ((chunk_neighbours[chunk_right] == external_face) && (tile_neighbours[tile_right] == external_tile)) {
+      // DO k=y_min-depth,y_max+depth
+
+      double *density1 = field.density1.data;
+#pragma omp target teams distribute parallel for simd clover_use_target(use_target)
+      for (int k = (y_min - depth + 1); k < (y_max + depth + 2); k++) {
+        for (int j = 0; j < depth; ++j) {
+          density1[(x_max + 2 + j) + (k)*base_stride] = density1[(x_max + 1 - j) + (k)*base_stride];
+        }
+      }
+    }
+  }
+
+  if (fields[field_energy0] == 1) {
+    if ((chunk_neighbours[chunk_bottom] == external_face) && (tile_neighbours[tile_bottom] == external_tile)) {
+      //  DO j=x_min-depth,x_max+depth
+
+      double *energy0 = field.energy0.data;
+#pragma omp target teams distribute parallel for simd clover_use_target(use_target)
+      for (int j = (x_min - depth + 1); j < (x_max + depth + 2); j++) {
+        for (int k = 0; k < depth; ++k) {
+          energy0[j + (1 - k) * base_stride] = energy0[j + (2 + k) * base_stride];
+        }
+      }
+    }
+    if ((chunk_neighbours[chunk_top] == external_face) && (tile_neighbours[tile_top] == external_tile)) {
+      // DO j=x_min-depth,x_max+depth
+
+      double *energy0 = field.energy0.data;
+#pragma omp target teams distribute parallel for simd clover_use_target(use_target)
+      for (int j = (x_min - depth + 1); j < (x_max + depth + 2); j++) {
+        for (int k = 0; k < depth; ++k) {
+          energy0[j + (y_max + 2 + k) * base_stride] = energy0[j + (y_max + 1 - k) * base_stride];
+        }
+      }
+    }
+    if ((chunk_neighbours[chunk_left] == external_face) && (tile_neighbours[tile_left] == external_tile)) {
+      // DO k=y_min-depth,y_max+depth
+
+      double *energy0 = field.energy0.data;
+#pragma omp target teams distribute parallel for simd clover_use_target(use_target)
+      for (int k = (y_min - depth + 1); k < (y_max + depth + 2); k++) {
+        for (int j = 0; j < depth; ++j) {
+          energy0[(1 - j) + (k)*base_stride] = energy0[(2 + j) + (k)*base_stride];
+        }
+      }
+    }
+    if ((chunk_neighbours[chunk_right] == external_face) && (tile_neighbours[tile_right] == external_tile)) {
+      // DO k=y_min-depth,y_max+depth
+
+      double *energy0 = field.energy0.data;
+#pragma omp target teams distribute parallel for simd clover_use_target(use_target)
+      for (int k = (y_min - depth + 1); k < (y_max + depth + 2); k++) {
+        for (int j = 0; j < depth; ++j) {
+          energy0[(x_max + 2 + j) + (k)*base_stride] = energy0[(x_max + 1 - j) + (k)*base_stride];
+        }
+      }
+    }
+  }
+
+  if (fields[field_energy1] == 1) {
+    if ((chunk_neighbours[chunk_bottom] == external_face) && (tile_neighbours[tile_bottom] == external_tile)) {
+      // DO j=x_min-depth,x_max+depth
+
+      double *energy1 = field.energy1.data;
+#pragma omp target teams distribute parallel for simd clover_use_target(use_target)
+      for (int j = (x_min - depth + 1); j < (x_max + depth + 2); j++) {
+        for (int k = 0; k < depth; ++k) {
+          energy1[j + (1 - k) * base_stride] = energy1[j + (2 + k) * base_stride];
+        }
+      }
+    }
+    if ((chunk_neighbours[chunk_top] == external_face) && (tile_neighbours[tile_top] == external_tile)) {
+      // DO j=x_min-depth,x_max+depth
+
+      double *energy1 = field.energy1.data;
+#pragma omp target teams distribute parallel for simd clover_use_target(use_target)
+      for (int j = (x_min - depth + 1); j < (x_max + depth + 2); j++) {
+        for (int k = 0; k < depth; ++k) {
+          energy1[j + (y_max + 2 + k) * base_stride] = energy1[j + (y_max + 1 - k) * base_stride];
+        }
+      }
+    }
+    if ((chunk_neighbours[chunk_left] == external_face) && (tile_neighbours[tile_left] == external_tile)) {
+      // DO k=y_min-depth,y_max+depth
+
+      double *energy1 = field.energy1.data;
+#pragma omp target teams distribute parallel for simd clover_use_target(use_target)
+      for (int k = (y_min - depth + 1); k < (y_max + depth + 2); k++) {
+        for (int j = 0; j < depth; ++j) {
+          energy1[(1 - j) + (k)*base_stride] = energy1[(2 + j) + (k)*base_stride];
+        }
+      }
+    }
+    if ((chunk_neighbours[chunk_right] == external_face) && (tile_neighbours[tile_right] == external_tile)) {
+      // DO k=y_min-depth,y_max+depth
+
+      double *energy1 = field.energy1.data;
+#pragma omp target teams distribute parallel for simd clover_use_target(use_target)
+      for (int k = (y_min - depth + 1); k < (y_max + depth + 2); k++) {
+        for (int j = 0; j < depth; ++j) {
+          energy1[(x_max + 2 + j) + (k)*base_stride] = energy1[(x_max + 1 - j) + (k)*base_stride];
+        }
+      }
+    }
+  }
+
+  if (fields[field_pressure] == 1) {
+    if ((chunk_neighbours[chunk_bottom] == external_face) && (tile_neighbours[tile_bottom] == external_tile)) {
+      // DO j=x_min-depth,x_max+depth
+
+      double *pressure = field.pressure.data;
+#pragma omp target teams distribute parallel for simd clover_use_target(use_target)
+      for (int j = (x_min - depth + 1); j < (x_max + depth + 2); j++) {
+        for (int k = 0; k < depth; ++k) {
+          pressure[j + (1 - k) * base_stride] = pressure[j + (2 + k) * base_stride];
+        }
+      }
+    }
+    if ((chunk_neighbours[chunk_top] == external_face) && (tile_neighbours[tile_top] == external_tile)) {
+      // DO j=x_min-depth,x_max+depth
+
+      double *pressure = field.pressure.data;
+#pragma omp target teams distribute parallel for simd clover_use_target(use_target)
+      for (int j = (x_min - depth + 1); j < (x_max + depth + 2); j++) {
+        for (int k = 0; k < depth; ++k) {
+          pressure[j + (y_max + 2 + k) * base_stride] = pressure[j + (y_max + 1 - k) * base_stride];
+        }
+      }
+    }
+    if ((chunk_neighbours[chunk_left] == external_face) && (tile_neighbours[tile_left] == external_tile)) {
+      // DO k=y_min-depth,y_max+depth
+
+      double *pressure = field.pressure.data;
+#pragma omp target teams distribute parallel for simd clover_use_target(use_target)
+      for (int k = (y_min - depth + 1); k < (y_max + depth + 2); k++) {
+        for (int j = 0; j < depth; ++j) {
+          pressure[(1 - j) + (k)*base_stride] = pressure[(2 + j) + (k)*base_stride];
+        }
+      }
+    }
+    if ((chunk_neighbours[chunk_right] == external_face) && (tile_neighbours[tile_right] == external_tile)) {
+      // DO k=y_min-depth,y_max+depth
+
+      double *pressure = field.pressure.data;
+#pragma omp target teams distribute parallel for simd clover_use_target(use_target)
+      for (int k = (y_min - depth + 1); k < (y_max + depth + 2); k++) {
+        for (int j = 0; j < depth; ++j) {
+          pressure[(x_max + 2 + j) + (k)*base_stride] = pressure[(x_max + 1 - j) + (k)*base_stride];
+        }
+      }
+    }
+  }
+
+  if (fields[field_viscosity] == 1) {
+    if ((chunk_neighbours[chunk_bottom] == external_face) && (tile_neighbours[tile_bottom] == external_tile)) {
+      // DO j=x_min-depth,x_max+depth
+
+      double *viscosity = field.viscosity.data;
+#pragma omp target teams distribute parallel for simd clover_use_target(use_target)
+      for (int j = (x_min - depth + 1); j < (x_max + depth + 2); j++) {
+        for (int k = 0; k < depth; ++k) {
+          viscosity[j + (1 - k) * base_stride] = viscosity[j + (2 + k) * base_stride];
+        }
+      }
+    }
+    if ((chunk_neighbours[chunk_top] == external_face) && (tile_neighbours[tile_top] == external_tile)) {
+      // DO j=x_min-depth,x_max+depth
+
+      double *viscosity = field.viscosity.data;
+#pragma omp target teams distribute parallel for simd clover_use_target(use_target)
+      for (int j = (x_min - depth + 1); j < (x_max + depth + 2); j++) {
+        for (int k = 0; k < depth; ++k) {
+          viscosity[j + (y_max + 2 + k) * base_stride] = viscosity[j + (y_max + 1 - k) * base_stride];
+        }
+      }
+    }
+    if ((chunk_neighbours[chunk_left] == external_face) && (tile_neighbours[tile_left] == external_tile)) {
+      // DO k=y_min-depth,y_max+depth
+
+      double *viscosity = field.viscosity.data;
+#pragma omp target teams distribute parallel for simd clover_use_target(use_target)
+      for (int k = (y_min - depth + 1); k < (y_max + depth + 2); k++) {
+        for (int j = 0; j < depth; ++j) {
+          viscosity[(1 - j) + (k)*base_stride] = viscosity[(2 + j) + (k)*base_stride];
+        }
+      }
+    }
+    if ((chunk_neighbours[chunk_right] == external_face) && (tile_neighbours[tile_right] == external_tile)) {
+      // DO k=y_min-depth,y_max+depth
+
+      double *viscosity = field.viscosity.data;
+#pragma omp target teams distribute parallel for simd clover_use_target(use_target)
+      for (int k = (y_min - depth + 1); k < (y_max + depth + 2); k++) {
+        for (int j = 0; j < depth; ++j) {
+          viscosity[(x_max + 2 + j) + (k)*base_stride] = viscosity[(x_max + 1 - j) + (k)*base_stride];
+        }
+      }
+    }
+  }
+
+  if (fields[field_soundspeed] == 1) {
+    if ((chunk_neighbours[chunk_bottom] == external_face) && (tile_neighbours[tile_bottom] == external_tile)) {
+      // DO j=x_min-depth,x_max+depth
+
+      double *soundspeed = field.soundspeed.data;
+#pragma omp target teams distribute parallel for simd clover_use_target(use_target)
+      for (int j = (x_min - depth + 1); j < (x_max + depth + 2); j++) {
+        for (int k = 0; k < depth; ++k) {
+          soundspeed[j + (1 - k) * base_stride] = soundspeed[j + (+k) * base_stride];
+        }
+      }
+    }
+    if ((chunk_neighbours[chunk_top] == external_face) && (tile_neighbours[tile_top] == external_tile)) {
+      // DO j=x_min-depth,x_max+depth
+
+      double *soundspeed = field.soundspeed.data;
+#pragma omp target teams distribute parallel for simd clover_use_target(use_target)
+      for (int j = (x_min - depth + 1); j < (x_max + depth + 2); j++) {
+        for (int k = 0; k < depth; ++k) {
+          soundspeed[j + (y_max + 2 + k) * base_stride] = soundspeed[j + (y_max + 1 - k) * base_stride];
+        }
+      }
+    }
+    if ((chunk_neighbours[chunk_left] == external_face) && (tile_neighbours[tile_left] == external_tile)) {
+      //  DO k=y_min-depth,y_max+depth
+
+      double *soundspeed = field.soundspeed.data;
+#pragma omp target teams distribute parallel for simd clover_use_target(use_target)
+      for (int k = (y_min - depth + 1); k < (y_max + depth + 2); k++) {
+        for (int j = 0; j < depth; ++j) {
+          soundspeed[(1 - j) + (k)*base_stride] = soundspeed[(2 + j) + (k)*base_stride];
+        }
+      }
+    }
+    if ((chunk_neighbours[chunk_right] == external_face) && (tile_neighbours[tile_right] == external_tile)) {
+      //  DO k=y_min-depth,y_max+depth
+
+      double *soundspeed = field.soundspeed.data;
+#pragma omp target teams distribute parallel for simd clover_use_target(use_target)
+      for (int k = (y_min - depth + 1); k < (y_max + depth + 2); k++) {
+        for (int j = 0; j < depth; ++j) {
+          soundspeed[(x_max + 2 + j) + (k)*base_stride] = soundspeed[(x_max + 1 - j) + (k)*base_stride];
+        }
+      }
+    }
+  }
+
+  if (fields[field_xvel0] == 1) {
+
+    if ((chunk_neighbours[chunk_bottom] == external_face) && (tile_neighbours[tile_bottom] == external_tile)) {
+      // DO j=x_min-depth,x_max+1+depth
+
+      double *xvel0 = field.xvel0.data;
+#pragma omp target teams distribute parallel for simd clover_use_target(use_target)
+      for (int j = (x_min - depth + 1); j < (x_max + 1 + depth + 2); j++) {
+        for (int k = 0; k < depth; ++k) {
+          xvel0[j + (1 - k) * vels_wk_stride] = xvel0[j + (1 + 2 + k) * vels_wk_stride];
+        }
+      }
+    }
+    if ((chunk_neighbours[chunk_top] == external_face) && (tile_neighbours[tile_top] == external_tile)) {
+      // DO j=x_min-depth,x_max+1+depth
+
+      double *xvel0 = field.xvel0.data;
+#pragma omp target teams distribute parallel for simd clover_use_target(use_target)
+      for (int j = (x_min - depth + 1); j < (x_max + 1 + depth + 2); j++) {
+        for (int k = 0; k < depth; ++k) {
+          xvel0[j + (y_max + 1 + 2 + k) * vels_wk_stride] = xvel0[j + (y_max + 1 - k) * vels_wk_stride];
+        }
+      }
+    }
+    if ((chunk_neighbours[chunk_left] == external_face) && (tile_neighbours[tile_left] == external_tile)) {
+      // DO k=y_min-depth,y_max+1+depth
+
+      double *xvel0 = field.xvel0.data;
+#pragma omp target teams distribute parallel for simd clover_use_target(use_target)
+      for (int k = (y_min - depth + 1); k < (y_max + 1 + depth + 2); k++) {
+        for (int j = 0; j < depth; ++j) {
+          xvel0[(1 - j) + (k)*vels_wk_stride] = -xvel0[(1 + 2 + j) + (k)*vels_wk_stride];
+        }
+      }
+    }
+    if ((chunk_neighbours[chunk_right] == external_face) && (tile_neighbours[tile_right] == external_tile)) {
+      // DO k=y_min-depth,y_max+1+depth
+
+      double *xvel0 = field.xvel0.data;
+#pragma omp target teams distribute parallel for simd clover_use_target(use_target)
+      for (int k = (y_min - depth + 1); k < (y_max + 1 + depth + 2); k++) {
+        for (int j = 0; j < depth; ++j) {
+          xvel0[(x_max + 2 + 1 + j) + (k)*vels_wk_stride] = -xvel0[(x_max + 1 - j) + (k)*vels_wk_stride];
+        }
+      }
+    }
+  }
+
+  if (fields[field_xvel1] == 1) {
+    if ((chunk_neighbours[chunk_bottom] == external_face) && (tile_neighbours[tile_bottom] == external_tile)) {
+      // DO j=x_min-depth,x_max+1+depth
+
+      double *xvel1 = field.xvel1.data;
+#pragma omp target teams distribute parallel for simd clover_use_target(use_target)
+      for (int j = (x_min - depth + 1); j < (x_max + 1 + depth + 2); j++) {
+        for (int k = 0; k < depth; ++k) {
+          xvel1[j + (1 - k) * vels_wk_stride] = xvel1[j + (1 + 2 + k) * vels_wk_stride];
+        }
+      }
+    }
+    if ((chunk_neighbours[chunk_top] == external_face) && (tile_neighbours[tile_top] == external_tile)) {
+      // DO j=x_min-depth,x_max+1+depth
+
+      double *xvel1 = field.xvel1.data;
+#pragma omp target teams distribute parallel for simd clover_use_target(use_target)
+      for (int j = (x_min - depth + 1); j < (x_max + 1 + depth + 2); j++) {
+        for (int k = 0; k < depth; ++k) {
+          xvel1[j + (y_max + 1 + 2 + k) * vels_wk_stride] = xvel1[j + (y_max + 1 - k) * vels_wk_stride];
+        }
+      }
+    }
+    if ((chunk_neighbours[chunk_left] == external_face) && (tile_neighbours[tile_left] == external_tile)) {
+      // DO k=y_min-depth,y_max+1+depth
+
+      double *xvel1 = field.xvel1.data;
+#pragma omp target teams distribute parallel for simd clover_use_target(use_target)
+      for (int k = (y_min - depth + 1); k < (y_max + 1 + depth + 2); k++) {
+        for (int j = 0; j < depth; ++j) {
+          xvel1[(1 - j) + (k)*vels_wk_stride] = -xvel1[(1 + 2 + j) + (k)*vels_wk_stride];
+        }
+      }
+    }
+    if ((chunk_neighbours[chunk_right] == external_face) && (tile_neighbours[tile_right] == external_tile)) {
+      // DO k=y_min-depth,y_max+1+depth
+
+      double *xvel1 = field.xvel1.data;
+#pragma omp target teams distribute parallel for simd clover_use_target(use_target)
+      for (int k = (y_min - depth + 1); k < (y_max + 1 + depth + 2); k++) {
+        for (int j = 0; j < depth; ++j) {
+          xvel1[(x_max + 2 + 1 + j) + (k)*vels_wk_stride] = -xvel1[(x_max + 1 - j) + (k)*vels_wk_stride];
+        }
+      }
+    }
+  }
+
+  if (fields[field_yvel0] == 1) {
+    if ((chunk_neighbours[chunk_bottom] == external_face) && (tile_neighbours[tile_bottom] == external_tile)) {
+      // DO j=x_min-depth,x_max+1+depth
+
+      double *yvel0 = field.yvel0.data;
+#pragma omp target teams distribute parallel for simd clover_use_target(use_target)
+      for (int j = (x_min - depth + 1); j < (x_max + 1 + depth + 2); j++) {
+        for (int k = 0; k < depth; ++k) {
+          yvel0[j + (1 - k) * vels_wk_stride] = -yvel0[j + (1 + 2 + k) * vels_wk_stride];
+        }
+      }
+    }
+    if ((chunk_neighbours[chunk_top] == external_face) && (tile_neighbours[tile_top] == external_tile)) {
+      // DO j=x_min-depth,x_max+1+depth
+
+      double *yvel0 = field.yvel0.data;
+#pragma omp target teams distribute parallel for simd clover_use_target(use_target)
+      for (int j = (x_min - depth + 1); j < (x_max + 1 + depth + 2); j++) {
+        for (int k = 0; k < depth; ++k) {
+          yvel0[j + (y_max + 1 + 2 + k) * vels_wk_stride] = -yvel0[j + (y_max + 1 - k) * vels_wk_stride];
+        }
+      }
+    }
+    if ((chunk_neighbours[chunk_left] == external_face) && (tile_neighbours[tile_left] == external_tile)) {
+      // DO k=y_min-depth,y_max+1+depth
+
+      double *yvel0 = field.yvel0.data;
+#pragma omp target teams distribute parallel for simd clover_use_target(use_target)
+      for (int k = (y_min - depth + 1); k < (y_max + 1 + depth + 2); k++) {
+        for (int j = 0; j < depth; ++j) {
+          yvel0[(1 - j) + (k)*vels_wk_stride] = yvel0[(1 + 2 + j) + (k)*vels_wk_stride];
+        }
+      }
+    }
+    if ((chunk_neighbours[chunk_right] == external_face) && (tile_neighbours[tile_right] == external_tile)) {
+      // DO k=y_min-depth,y_max+1+depth
+
+      double *yvel0 = field.yvel0.data;
+#pragma omp target teams distribute parallel for simd clover_use_target(use_target)
+      for (int k = (y_min - depth + 1); k < (y_max + 1 + depth + 2); k++) {
+        for (int j = 0; j < depth; ++j) {
+          yvel0[(x_max + 2 + 1 + j) + (k)*vels_wk_stride] = yvel0[(x_max + 1 - j) + (k)*vels_wk_stride];
+        }
+      }
+    }
+  }
+
+  if (fields[field_yvel1] == 1) {
+    if ((chunk_neighbours[chunk_bottom] == external_face) && (tile_neighbours[tile_bottom] == external_tile)) {
+      // DO j=x_min-depth,x_max+1+depth
+
+      double *yvel1 = field.yvel1.data;
+#pragma omp target teams distribute parallel for simd clover_use_target(use_target)
+      for (int j = (x_min - depth + 1); j < (x_max + 1 + depth + 2); j++) {
+        for (int k = 0; k < depth; ++k) {
+          yvel1[j + (1 - k) * vels_wk_stride] = -yvel1[j + (1 + 2 + k) * vels_wk_stride];
+        }
+      }
+    }
+    if ((chunk_neighbours[chunk_top] == external_face) && (tile_neighbours[tile_top] == external_tile)) {
+      // DO j=x_min-depth,x_max+1+depth
+
+      double *yvel1 = field.yvel1.data;
+#pragma omp target teams distribute parallel for simd clover_use_target(use_target)
+      for (int j = (x_min - depth + 1); j < (x_max + 1 + depth + 2); j++) {
+        for (int k = 0; k < depth; ++k) {
+          yvel1[j + (y_max + 1 + 2 + k) * vels_wk_stride] = -yvel1[j + (y_max + 1 - k) * vels_wk_stride];
+        }
+      }
+    }
+    if ((chunk_neighbours[chunk_left] == external_face) && (tile_neighbours[tile_left] == external_tile)) {
+      // DO k=y_min-depth,y_max+1+depth
+
+      double *yvel1 = field.yvel1.data;
+#pragma omp target teams distribute parallel for simd clover_use_target(use_target)
+      for (int k = (y_min - depth + 1); k < (y_max + 1 + depth + 2); k++) {
+        for (int j = 0; j < depth; ++j) {
+          yvel1[(1 - j) + (k)*vels_wk_stride] = yvel1[(1 + 2 + j) + (k)*vels_wk_stride];
+        }
+      }
+    }
+    if ((chunk_neighbours[chunk_right] == external_face) && (tile_neighbours[tile_right] == external_tile)) {
+      // DO k=y_min-depth,y_max+1+depth
+
+      double *yvel1 = field.yvel1.data;
+#pragma omp target teams distribute parallel for simd clover_use_target(use_target)
+      for (int k = (y_min - depth + 1); k < (y_max + 1 + depth + 2); k++) {
+        for (int j = 0; j < depth; ++j) {
+          yvel1[(x_max + 2 + 1 + j) + (k)*vels_wk_stride] = yvel1[(x_max + 1 - j) + (k)*vels_wk_stride];
+        }
+      }
+    }
+  }
+
+  if (fields[field_vol_flux_x] == 1) {
+    if ((chunk_neighbours[chunk_bottom] == external_face) && (tile_neighbours[tile_bottom] == external_tile)) {
+      // DO j=x_min-depth,x_max+1+depth
+
+      double *vol_flux_x = field.vol_flux_x.data;
+#pragma omp target teams distribute parallel for simd clover_use_target(use_target)
+      for (int j = (x_min - depth + 1); j < (x_max + 1 + depth + 2); j++) {
+        for (int k = 0; k < depth; ++k) {
+          vol_flux_x[j + (1 - k) * flux_x_stride] = vol_flux_x[j + (1 + 2 + k) * flux_x_stride];
+        }
+      }
+    }
+    if ((chunk_neighbours[chunk_top] == external_face) && (tile_neighbours[tile_top] == external_tile)) {
+      // DO j=x_min-depth,x_max+1+depth
+
+      double *vol_flux_x = field.vol_flux_x.data;
+#pragma omp target teams distribute parallel for simd clover_use_target(use_target)
+      for (int j = (x_min - depth + 1); j < (x_max + 1 + depth + 2); j++) {
+        for (int k = 0; k < depth; ++k) {
+          vol_flux_x[j + (y_max + 2 + k) * flux_x_stride] = vol_flux_x[j + (y_max - k) * flux_x_stride];
+        }
+      }
+    }
+    if ((chunk_neighbours[chunk_left] == external_face) && (tile_neighbours[tile_left] == external_tile)) {
+      // DO k=y_min-depth,y_max+depth
+
+      double *vol_flux_x = field.vol_flux_x.data;
+#pragma omp target teams distribute parallel for simd clover_use_target(use_target)
+      for (int k = (y_min - depth + 1); k < (y_max + depth + 2); k++) {
+        for (int j = 0; j < depth; ++j) {
+          vol_flux_x[(1 - j) + (k)*flux_x_stride] = -vol_flux_x[(1 + 2 + j) + (k)*flux_x_stride];
+        }
+      }
+    }
+    if ((chunk_neighbours[chunk_right] == external_face) && (tile_neighbours[tile_right] == external_tile)) {
+      // DO k=y_min-depth,y_max+depth
+
+      double *vol_flux_x = field.vol_flux_x.data;
+#pragma omp target teams distribute parallel for simd clover_use_target(use_target)
+      for (int k = (y_min - depth + 1); k < (y_max + depth + 2); k++) {
+        for (int j = 0; j < depth; ++j) {
+          vol_flux_x[(x_max + j + 1 + 2) + (k)*flux_x_stride] = -vol_flux_x[(x_max + 1 - j) + (k)*flux_x_stride];
+        }
+      }
+    }
+  }
+
+  if (fields[field_mass_flux_x] == 1) {
+    if ((chunk_neighbours[chunk_bottom] == external_face) && (tile_neighbours[tile_bottom] == external_tile)) {
+      // DO j=x_min-depth,x_max+1+depth
+
+      double *mass_flux_x = field.mass_flux_x.data;
+#pragma omp target teams distribute parallel for simd clover_use_target(use_target)
+      for (int j = (x_min - depth + 1); j < (x_max + 1 + depth + 2); j++) {
+        for (int k = 0; k < depth; ++k) {
+          mass_flux_x[j + (1 - k) * flux_x_stride] = mass_flux_x[j + (1 + 2 + k) * flux_x_stride];
+        }
+      }
+    }
+    if ((chunk_neighbours[chunk_top] == external_face) && (tile_neighbours[tile_top] == external_tile)) {
+      // DO j=x_min-depth,x_max+1+depth
+
+      double *mass_flux_x = field.mass_flux_x.data;
+#pragma omp target teams distribute parallel for simd clover_use_target(use_target)
+      for (int j = (x_min - depth + 1); j < (x_max + 1 + depth + 2); j++) {
+        for (int k = 0; k < depth; ++k) {
+          mass_flux_x[j + (y_max + 2 + k) * flux_x_stride] = mass_flux_x[j + (y_max - k) * flux_x_stride];
+        }
+      }
+    }
+    if ((chunk_neighbours[chunk_left] == external_face) && (tile_neighbours[tile_left] == external_tile)) {
+      // DO k=y_min-depth,y_max+depth
+
+      double *mass_flux_x = field.mass_flux_x.data;
+#pragma omp target teams distribute parallel for simd clover_use_target(use_target)
+      for (int k = (y_min - depth + 1); k < (y_max + depth + 2); k++) {
+        for (int j = 0; j < depth; ++j) {
+          mass_flux_x[(1 - j) + (k)*flux_x_stride] = -mass_flux_x[(1 + 2 + j) + (k)*flux_x_stride];
+        }
+      }
+    }
+    if ((chunk_neighbours[chunk_right] == external_face) && (tile_neighbours[tile_right] == external_tile)) {
+      // DO k=y_min-depth,y_max+depth
+
+      double *mass_flux_x = field.mass_flux_x.data;
+#pragma omp target teams distribute parallel for simd clover_use_target(use_target)
+      for (int k = (y_min - depth + 1); k < (y_max + depth + 2); k++) {
+        for (int j = 0; j < depth; ++j) {
+          mass_flux_x[(x_max + j + 1 + 2) + (k)*flux_x_stride] = -mass_flux_x[(x_max + 1 - j) + (k)*flux_x_stride];
+        }
+      }
+    }
+  }
+
+  if (fields[field_vol_flux_y] == 1) {
+    if ((chunk_neighbours[chunk_bottom] == external_face) && (tile_neighbours[tile_bottom] == external_tile)) {
+      // DO j=x_min-depth,x_max+depth
+
+      double *vol_flux_y = field.vol_flux_y.data;
+#pragma omp target teams distribute parallel for simd clover_use_target(use_target)
+      for (int j = (x_min - depth + 1); j < (x_max + depth + 2); j++) {
+        for (int k = 0; k < depth; ++k) {
+          vol_flux_y[j + (1 - k) * flux_y_stride] = -vol_flux_y[j + (1 + 2 + k) * flux_y_stride];
+        }
+      }
+    }
+    if ((chunk_neighbours[chunk_top] == external_face) && (tile_neighbours[tile_top] == external_tile)) {
+      // DO j=x_min-depth,x_max+depth
+
+      double *vol_flux_y = field.vol_flux_y.data;
+#pragma omp target teams distribute parallel for simd clover_use_target(use_target)
+      for (int j = (x_min - depth + 1); j < (x_max + depth + 2); j++) {
+        for (int k = 0; k < depth; ++k) {
+          vol_flux_y[j + (y_max + k + 1 + 2) * flux_y_stride] = -vol_flux_y[j + (y_max + 1 - k) * flux_y_stride];
+        }
+      }
+    }
+    if ((chunk_neighbours[chunk_left] == external_face) && (tile_neighbours[tile_left] == external_tile)) {
+      // DO k=y_min-depth,y_max+1+depth
+
+      double *vol_flux_y = field.vol_flux_y.data;
+#pragma omp target teams distribute parallel for simd clover_use_target(use_target)
+      for (int k = (y_min - depth + 1); k < (y_max + 1 + depth + 2); k++) {
+        for (int j = 0; j < depth; ++j) {
+          vol_flux_y[(1 - j) + (k)*flux_y_stride] = vol_flux_y[(1 + 2 + j) + (k)*flux_y_stride];
+        }
+      }
+    }
+    if ((chunk_neighbours[chunk_right] == external_face) && (tile_neighbours[tile_right] == external_tile)) {
+      // DO k=y_min-depth,y_max+1+depth
+
+      double *vol_flux_y = field.vol_flux_y.data;
+#pragma omp target teams distribute parallel for simd clover_use_target(use_target)
+      for (int k = (y_min - depth + 1); k < (y_max + 1 + depth + 2); k++) {
+        for (int j = 0; j < depth; ++j) {
+          vol_flux_y[(x_max + 2 + j) + (k)*flux_y_stride] = vol_flux_y[(x_max - j) + (k)*flux_y_stride];
+        }
+      }
+    }
+  }
+
+  if (fields[field_mass_flux_y] == 1) {
+    if ((chunk_neighbours[chunk_bottom] == external_face) && (tile_neighbours[tile_bottom] == external_tile)) {
+      // DO j=x_min-depth,x_max+depth
+
+      double *mass_flux_y = field.mass_flux_y.data;
+#pragma omp target teams distribute parallel for simd clover_use_target(use_target)
+      for (int j = (x_min - depth + 1); j < (x_max + depth + 2); j++) {
+        for (int k = 0; k < depth; ++k) {
+          mass_flux_y[j + (1 - k) * flux_y_stride] = -mass_flux_y[j + (1 + 2 + k) * flux_y_stride];
+        }
+      }
+    }
+    if ((chunk_neighbours[chunk_top] == external_face) && (tile_neighbours[tile_top] == external_tile)) {
+      // DO j=x_min-depth,x_max+depth
+
+      double *mass_flux_y = field.mass_flux_y.data;
+#pragma omp target teams distribute parallel for simd clover_use_target(use_target)
+      for (int j = (x_min - depth + 1); j < (x_max + depth + 2); j++) {
+        for (int k = 0; k < depth; ++k) {
+          mass_flux_y[j + (y_max + k + 1 + 2) * flux_y_stride] = -mass_flux_y[j + (y_max + 1 - k) * flux_y_stride];
+        }
+      }
+    }
+    if ((chunk_neighbours[chunk_left] == external_face) && (tile_neighbours[tile_left] == external_tile)) {
+      // DO k=y_min-depth,y_max+1+depth
+
+      double *mass_flux_y = field.mass_flux_y.data;
+#pragma omp target teams distribute parallel for simd clover_use_target(use_target)
+      for (int k = (y_min - depth + 1); k < (y_max + 1 + depth + 2); k++) {
+        for (int j = 0; j < depth; ++j) {
+          mass_flux_y[(1 - j) + (k)*flux_y_stride] = mass_flux_y[(1 + 2 + j) + (k)*flux_y_stride];
+        }
+      }
+    }
+    if ((chunk_neighbours[chunk_right] == external_face) && (tile_neighbours[tile_right] == external_tile)) {
+      // DO k=y_min-depth,y_max+1+depth
+
+      double *mass_flux_y = field.mass_flux_y.data;
+#pragma omp target teams distribute parallel for simd clover_use_target(use_target)
+      for (int k = (y_min - depth + 1); k < (y_max + 1 + depth + 2); k++) {
+        for (int j = 0; j < depth; ++j) {
+          mass_flux_y[(x_max + 2 + j) + (k)*flux_y_stride] = mass_flux_y[(x_max - j) + (k)*flux_y_stride];
+        }
+      }
+    }
+  }
+}
+
+//  @brief Driver for the halo updates
+//  @author Wayne Gaudin
+//  @details Invokes the kernels for the internal and external halo cells for
+//  the fields specified.
+void update_halo(global_variables &globals, int fields[NUM_FIELDS], int depth) {
+
+  double kernel_time = 0;
+  if (globals.profiler_on) kernel_time = timer();
+  update_tile_halo(globals, fields, depth);
+  if (globals.profiler_on) {
+    globals.profiler.tile_halo_exchange += timer() - kernel_time;
+    kernel_time = timer();
+  }
+
+  clover_exchange(globals, fields, depth);
+
+  if (globals.profiler_on) {
+    globals.profiler.mpi_halo_exchange += timer() - kernel_time;
+    kernel_time = timer();
+  }
+
+  if ((globals.chunk.chunk_neighbours[chunk_left] == external_face) || (globals.chunk.chunk_neighbours[chunk_right] == external_face) ||
+      (globals.chunk.chunk_neighbours[chunk_bottom] == external_face) || (globals.chunk.chunk_neighbours[chunk_top] == external_face)) {
+
+#if SYNC_BUFFERS
+    globals.hostToDevice();
+#endif
+
+    for (int tile = 0; tile < globals.config.tiles_per_chunk; ++tile) {
+      tile_type &t = globals.chunk.tiles[tile];
+      update_halo_kernel(globals.context.use_target, t.info.t_xmin, t.info.t_xmax, t.info.t_ymin, t.info.t_ymax,
+                         globals.chunk.chunk_neighbours, t.info.tile_neighbours, t.field, fields, depth);
+    }
+
+#if SYNC_BUFFERS
+    globals.deviceToHost();
+#endif
+  }
+
+  if (globals.profiler_on) globals.profiler.self_halo_exchange += timer() - kernel_time;
+}

--- a/src/acc/update_halo.cpp
+++ b/src/acc/update_halo.cpp
@@ -45,7 +45,8 @@ void update_halo_kernel(bool use_target, int x_min, int x_max, int y_min, int y_
       // DO j=x_min-depth,x_max+depth
 
       double *density0 = field.density0.data;
-#pragma omp target teams distribute parallel for simd clover_use_target(use_target)
+
+#pragma acc parallel loop gang worker vector default(present) clover_use_target(use_target)
       for (int j = (x_min - depth + 1); j < (x_max + depth + 2); j++) {
         for (int k = 0; k < depth; ++k) {
           density0[j + (1 - k) * base_stride] = density0[j + (2 + k) * base_stride];
@@ -56,7 +57,7 @@ void update_halo_kernel(bool use_target, int x_min, int x_max, int y_min, int y_
       // DO j=x_min-depth,x_max+depth
 
       double *density0 = field.density0.data;
-#pragma omp target teams distribute parallel for simd clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector default(present) clover_use_target(use_target)
       for (int j = (x_min - depth + 1); j < (x_max + depth + 2); j++) {
         for (int k = 0; k < depth; ++k) {
           density0[j + (y_max + 2 + k) * base_stride] = density0[j + (y_max + 1 - k) * base_stride];
@@ -67,7 +68,7 @@ void update_halo_kernel(bool use_target, int x_min, int x_max, int y_min, int y_
       // DO k=y_min-depth,y_max+depth
 
       double *density0 = field.density0.data;
-#pragma omp target teams distribute parallel for simd clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector default(present) clover_use_target(use_target)
       for (int k = (y_min - depth + 1); k < (y_max + depth + 2); k++) {
         for (int j = 0; j < depth; ++j) {
           density0[(1 - j) + (k)*base_stride] = density0[(2 + j) + (k)*base_stride];
@@ -78,7 +79,7 @@ void update_halo_kernel(bool use_target, int x_min, int x_max, int y_min, int y_
       // DO k=y_min-depth,y_max+depth
 
       double *density0 = field.density0.data;
-#pragma omp target teams distribute parallel for simd clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector default(present) clover_use_target(use_target)
       for (int k = (y_min - depth + 1); k < (y_max + depth + 2); k++) {
         for (int j = 0; j < depth; ++j) {
           density0[(x_max + 2 + j) + (k)*base_stride] = density0[(x_max + 1 - j) + (k)*base_stride];
@@ -92,7 +93,7 @@ void update_halo_kernel(bool use_target, int x_min, int x_max, int y_min, int y_
       // DO k=y_min-depth,y_max+depth
 
       double *density1 = field.density1.data;
-#pragma omp target teams distribute parallel for simd clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector default(present) clover_use_target(use_target)
       for (int j = (x_min - depth + 1); j < (x_max + depth + 2); j++) {
         for (int k = 0; k < depth; ++k) {
           density1[j + (1 - k) * base_stride] = density1[j + (2 + k) * base_stride];
@@ -103,7 +104,7 @@ void update_halo_kernel(bool use_target, int x_min, int x_max, int y_min, int y_
       // DO j=x_min-depth,x_max+depth
 
       double *density1 = field.density1.data;
-#pragma omp target teams distribute parallel for simd clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector default(present) clover_use_target(use_target)
       for (int j = (x_min - depth + 1); j < (x_max + depth + 2); j++) {
         for (int k = 0; k < depth; ++k) {
           density1[j + (y_max + 2 + k) * base_stride] = density1[j + (y_max + 1 - k) * base_stride];
@@ -114,7 +115,7 @@ void update_halo_kernel(bool use_target, int x_min, int x_max, int y_min, int y_
       // DO k=y_min-depth,y_max+depth
 
       double *density1 = field.density1.data;
-#pragma omp target teams distribute parallel for simd clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector default(present) clover_use_target(use_target)
       for (int k = (y_min - depth + 1); k < (y_max + depth + 2); k++) {
         for (int j = 0; j < depth; ++j) {
           density1[(1 - j) + (k)*base_stride] = density1[(2 + j) + (k)*base_stride];
@@ -125,7 +126,7 @@ void update_halo_kernel(bool use_target, int x_min, int x_max, int y_min, int y_
       // DO k=y_min-depth,y_max+depth
 
       double *density1 = field.density1.data;
-#pragma omp target teams distribute parallel for simd clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector default(present) clover_use_target(use_target)
       for (int k = (y_min - depth + 1); k < (y_max + depth + 2); k++) {
         for (int j = 0; j < depth; ++j) {
           density1[(x_max + 2 + j) + (k)*base_stride] = density1[(x_max + 1 - j) + (k)*base_stride];
@@ -139,7 +140,7 @@ void update_halo_kernel(bool use_target, int x_min, int x_max, int y_min, int y_
       //  DO j=x_min-depth,x_max+depth
 
       double *energy0 = field.energy0.data;
-#pragma omp target teams distribute parallel for simd clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector default(present) clover_use_target(use_target)
       for (int j = (x_min - depth + 1); j < (x_max + depth + 2); j++) {
         for (int k = 0; k < depth; ++k) {
           energy0[j + (1 - k) * base_stride] = energy0[j + (2 + k) * base_stride];
@@ -150,7 +151,7 @@ void update_halo_kernel(bool use_target, int x_min, int x_max, int y_min, int y_
       // DO j=x_min-depth,x_max+depth
 
       double *energy0 = field.energy0.data;
-#pragma omp target teams distribute parallel for simd clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector default(present) clover_use_target(use_target)
       for (int j = (x_min - depth + 1); j < (x_max + depth + 2); j++) {
         for (int k = 0; k < depth; ++k) {
           energy0[j + (y_max + 2 + k) * base_stride] = energy0[j + (y_max + 1 - k) * base_stride];
@@ -161,7 +162,7 @@ void update_halo_kernel(bool use_target, int x_min, int x_max, int y_min, int y_
       // DO k=y_min-depth,y_max+depth
 
       double *energy0 = field.energy0.data;
-#pragma omp target teams distribute parallel for simd clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector default(present) clover_use_target(use_target)
       for (int k = (y_min - depth + 1); k < (y_max + depth + 2); k++) {
         for (int j = 0; j < depth; ++j) {
           energy0[(1 - j) + (k)*base_stride] = energy0[(2 + j) + (k)*base_stride];
@@ -172,7 +173,7 @@ void update_halo_kernel(bool use_target, int x_min, int x_max, int y_min, int y_
       // DO k=y_min-depth,y_max+depth
 
       double *energy0 = field.energy0.data;
-#pragma omp target teams distribute parallel for simd clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector default(present) clover_use_target(use_target)
       for (int k = (y_min - depth + 1); k < (y_max + depth + 2); k++) {
         for (int j = 0; j < depth; ++j) {
           energy0[(x_max + 2 + j) + (k)*base_stride] = energy0[(x_max + 1 - j) + (k)*base_stride];
@@ -186,7 +187,7 @@ void update_halo_kernel(bool use_target, int x_min, int x_max, int y_min, int y_
       // DO j=x_min-depth,x_max+depth
 
       double *energy1 = field.energy1.data;
-#pragma omp target teams distribute parallel for simd clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector default(present) clover_use_target(use_target)
       for (int j = (x_min - depth + 1); j < (x_max + depth + 2); j++) {
         for (int k = 0; k < depth; ++k) {
           energy1[j + (1 - k) * base_stride] = energy1[j + (2 + k) * base_stride];
@@ -197,7 +198,7 @@ void update_halo_kernel(bool use_target, int x_min, int x_max, int y_min, int y_
       // DO j=x_min-depth,x_max+depth
 
       double *energy1 = field.energy1.data;
-#pragma omp target teams distribute parallel for simd clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector default(present) clover_use_target(use_target)
       for (int j = (x_min - depth + 1); j < (x_max + depth + 2); j++) {
         for (int k = 0; k < depth; ++k) {
           energy1[j + (y_max + 2 + k) * base_stride] = energy1[j + (y_max + 1 - k) * base_stride];
@@ -208,7 +209,7 @@ void update_halo_kernel(bool use_target, int x_min, int x_max, int y_min, int y_
       // DO k=y_min-depth,y_max+depth
 
       double *energy1 = field.energy1.data;
-#pragma omp target teams distribute parallel for simd clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector default(present) clover_use_target(use_target)
       for (int k = (y_min - depth + 1); k < (y_max + depth + 2); k++) {
         for (int j = 0; j < depth; ++j) {
           energy1[(1 - j) + (k)*base_stride] = energy1[(2 + j) + (k)*base_stride];
@@ -219,7 +220,7 @@ void update_halo_kernel(bool use_target, int x_min, int x_max, int y_min, int y_
       // DO k=y_min-depth,y_max+depth
 
       double *energy1 = field.energy1.data;
-#pragma omp target teams distribute parallel for simd clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector default(present) clover_use_target(use_target)
       for (int k = (y_min - depth + 1); k < (y_max + depth + 2); k++) {
         for (int j = 0; j < depth; ++j) {
           energy1[(x_max + 2 + j) + (k)*base_stride] = energy1[(x_max + 1 - j) + (k)*base_stride];
@@ -233,7 +234,7 @@ void update_halo_kernel(bool use_target, int x_min, int x_max, int y_min, int y_
       // DO j=x_min-depth,x_max+depth
 
       double *pressure = field.pressure.data;
-#pragma omp target teams distribute parallel for simd clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector default(present) clover_use_target(use_target)
       for (int j = (x_min - depth + 1); j < (x_max + depth + 2); j++) {
         for (int k = 0; k < depth; ++k) {
           pressure[j + (1 - k) * base_stride] = pressure[j + (2 + k) * base_stride];
@@ -244,7 +245,7 @@ void update_halo_kernel(bool use_target, int x_min, int x_max, int y_min, int y_
       // DO j=x_min-depth,x_max+depth
 
       double *pressure = field.pressure.data;
-#pragma omp target teams distribute parallel for simd clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector default(present) clover_use_target(use_target)
       for (int j = (x_min - depth + 1); j < (x_max + depth + 2); j++) {
         for (int k = 0; k < depth; ++k) {
           pressure[j + (y_max + 2 + k) * base_stride] = pressure[j + (y_max + 1 - k) * base_stride];
@@ -255,7 +256,7 @@ void update_halo_kernel(bool use_target, int x_min, int x_max, int y_min, int y_
       // DO k=y_min-depth,y_max+depth
 
       double *pressure = field.pressure.data;
-#pragma omp target teams distribute parallel for simd clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector default(present) clover_use_target(use_target)
       for (int k = (y_min - depth + 1); k < (y_max + depth + 2); k++) {
         for (int j = 0; j < depth; ++j) {
           pressure[(1 - j) + (k)*base_stride] = pressure[(2 + j) + (k)*base_stride];
@@ -266,7 +267,7 @@ void update_halo_kernel(bool use_target, int x_min, int x_max, int y_min, int y_
       // DO k=y_min-depth,y_max+depth
 
       double *pressure = field.pressure.data;
-#pragma omp target teams distribute parallel for simd clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector default(present) clover_use_target(use_target)
       for (int k = (y_min - depth + 1); k < (y_max + depth + 2); k++) {
         for (int j = 0; j < depth; ++j) {
           pressure[(x_max + 2 + j) + (k)*base_stride] = pressure[(x_max + 1 - j) + (k)*base_stride];
@@ -280,7 +281,7 @@ void update_halo_kernel(bool use_target, int x_min, int x_max, int y_min, int y_
       // DO j=x_min-depth,x_max+depth
 
       double *viscosity = field.viscosity.data;
-#pragma omp target teams distribute parallel for simd clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector default(present) clover_use_target(use_target)
       for (int j = (x_min - depth + 1); j < (x_max + depth + 2); j++) {
         for (int k = 0; k < depth; ++k) {
           viscosity[j + (1 - k) * base_stride] = viscosity[j + (2 + k) * base_stride];
@@ -291,7 +292,7 @@ void update_halo_kernel(bool use_target, int x_min, int x_max, int y_min, int y_
       // DO j=x_min-depth,x_max+depth
 
       double *viscosity = field.viscosity.data;
-#pragma omp target teams distribute parallel for simd clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector default(present) clover_use_target(use_target)
       for (int j = (x_min - depth + 1); j < (x_max + depth + 2); j++) {
         for (int k = 0; k < depth; ++k) {
           viscosity[j + (y_max + 2 + k) * base_stride] = viscosity[j + (y_max + 1 - k) * base_stride];
@@ -302,7 +303,7 @@ void update_halo_kernel(bool use_target, int x_min, int x_max, int y_min, int y_
       // DO k=y_min-depth,y_max+depth
 
       double *viscosity = field.viscosity.data;
-#pragma omp target teams distribute parallel for simd clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector default(present) clover_use_target(use_target)
       for (int k = (y_min - depth + 1); k < (y_max + depth + 2); k++) {
         for (int j = 0; j < depth; ++j) {
           viscosity[(1 - j) + (k)*base_stride] = viscosity[(2 + j) + (k)*base_stride];
@@ -313,7 +314,7 @@ void update_halo_kernel(bool use_target, int x_min, int x_max, int y_min, int y_
       // DO k=y_min-depth,y_max+depth
 
       double *viscosity = field.viscosity.data;
-#pragma omp target teams distribute parallel for simd clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector default(present) clover_use_target(use_target)
       for (int k = (y_min - depth + 1); k < (y_max + depth + 2); k++) {
         for (int j = 0; j < depth; ++j) {
           viscosity[(x_max + 2 + j) + (k)*base_stride] = viscosity[(x_max + 1 - j) + (k)*base_stride];
@@ -327,7 +328,7 @@ void update_halo_kernel(bool use_target, int x_min, int x_max, int y_min, int y_
       // DO j=x_min-depth,x_max+depth
 
       double *soundspeed = field.soundspeed.data;
-#pragma omp target teams distribute parallel for simd clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector default(present) clover_use_target(use_target)
       for (int j = (x_min - depth + 1); j < (x_max + depth + 2); j++) {
         for (int k = 0; k < depth; ++k) {
           soundspeed[j + (1 - k) * base_stride] = soundspeed[j + (+k) * base_stride];
@@ -338,7 +339,7 @@ void update_halo_kernel(bool use_target, int x_min, int x_max, int y_min, int y_
       // DO j=x_min-depth,x_max+depth
 
       double *soundspeed = field.soundspeed.data;
-#pragma omp target teams distribute parallel for simd clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector default(present) clover_use_target(use_target)
       for (int j = (x_min - depth + 1); j < (x_max + depth + 2); j++) {
         for (int k = 0; k < depth; ++k) {
           soundspeed[j + (y_max + 2 + k) * base_stride] = soundspeed[j + (y_max + 1 - k) * base_stride];
@@ -349,7 +350,7 @@ void update_halo_kernel(bool use_target, int x_min, int x_max, int y_min, int y_
       //  DO k=y_min-depth,y_max+depth
 
       double *soundspeed = field.soundspeed.data;
-#pragma omp target teams distribute parallel for simd clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector default(present) clover_use_target(use_target)
       for (int k = (y_min - depth + 1); k < (y_max + depth + 2); k++) {
         for (int j = 0; j < depth; ++j) {
           soundspeed[(1 - j) + (k)*base_stride] = soundspeed[(2 + j) + (k)*base_stride];
@@ -360,7 +361,7 @@ void update_halo_kernel(bool use_target, int x_min, int x_max, int y_min, int y_
       //  DO k=y_min-depth,y_max+depth
 
       double *soundspeed = field.soundspeed.data;
-#pragma omp target teams distribute parallel for simd clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector default(present) clover_use_target(use_target)
       for (int k = (y_min - depth + 1); k < (y_max + depth + 2); k++) {
         for (int j = 0; j < depth; ++j) {
           soundspeed[(x_max + 2 + j) + (k)*base_stride] = soundspeed[(x_max + 1 - j) + (k)*base_stride];
@@ -375,7 +376,7 @@ void update_halo_kernel(bool use_target, int x_min, int x_max, int y_min, int y_
       // DO j=x_min-depth,x_max+1+depth
 
       double *xvel0 = field.xvel0.data;
-#pragma omp target teams distribute parallel for simd clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector default(present) clover_use_target(use_target)
       for (int j = (x_min - depth + 1); j < (x_max + 1 + depth + 2); j++) {
         for (int k = 0; k < depth; ++k) {
           xvel0[j + (1 - k) * vels_wk_stride] = xvel0[j + (1 + 2 + k) * vels_wk_stride];
@@ -386,7 +387,7 @@ void update_halo_kernel(bool use_target, int x_min, int x_max, int y_min, int y_
       // DO j=x_min-depth,x_max+1+depth
 
       double *xvel0 = field.xvel0.data;
-#pragma omp target teams distribute parallel for simd clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector default(present) clover_use_target(use_target)
       for (int j = (x_min - depth + 1); j < (x_max + 1 + depth + 2); j++) {
         for (int k = 0; k < depth; ++k) {
           xvel0[j + (y_max + 1 + 2 + k) * vels_wk_stride] = xvel0[j + (y_max + 1 - k) * vels_wk_stride];
@@ -397,7 +398,7 @@ void update_halo_kernel(bool use_target, int x_min, int x_max, int y_min, int y_
       // DO k=y_min-depth,y_max+1+depth
 
       double *xvel0 = field.xvel0.data;
-#pragma omp target teams distribute parallel for simd clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector default(present) clover_use_target(use_target)
       for (int k = (y_min - depth + 1); k < (y_max + 1 + depth + 2); k++) {
         for (int j = 0; j < depth; ++j) {
           xvel0[(1 - j) + (k)*vels_wk_stride] = -xvel0[(1 + 2 + j) + (k)*vels_wk_stride];
@@ -408,7 +409,7 @@ void update_halo_kernel(bool use_target, int x_min, int x_max, int y_min, int y_
       // DO k=y_min-depth,y_max+1+depth
 
       double *xvel0 = field.xvel0.data;
-#pragma omp target teams distribute parallel for simd clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector default(present) clover_use_target(use_target)
       for (int k = (y_min - depth + 1); k < (y_max + 1 + depth + 2); k++) {
         for (int j = 0; j < depth; ++j) {
           xvel0[(x_max + 2 + 1 + j) + (k)*vels_wk_stride] = -xvel0[(x_max + 1 - j) + (k)*vels_wk_stride];
@@ -422,7 +423,7 @@ void update_halo_kernel(bool use_target, int x_min, int x_max, int y_min, int y_
       // DO j=x_min-depth,x_max+1+depth
 
       double *xvel1 = field.xvel1.data;
-#pragma omp target teams distribute parallel for simd clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector default(present) clover_use_target(use_target)
       for (int j = (x_min - depth + 1); j < (x_max + 1 + depth + 2); j++) {
         for (int k = 0; k < depth; ++k) {
           xvel1[j + (1 - k) * vels_wk_stride] = xvel1[j + (1 + 2 + k) * vels_wk_stride];
@@ -433,7 +434,7 @@ void update_halo_kernel(bool use_target, int x_min, int x_max, int y_min, int y_
       // DO j=x_min-depth,x_max+1+depth
 
       double *xvel1 = field.xvel1.data;
-#pragma omp target teams distribute parallel for simd clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector default(present) clover_use_target(use_target)
       for (int j = (x_min - depth + 1); j < (x_max + 1 + depth + 2); j++) {
         for (int k = 0; k < depth; ++k) {
           xvel1[j + (y_max + 1 + 2 + k) * vels_wk_stride] = xvel1[j + (y_max + 1 - k) * vels_wk_stride];
@@ -444,7 +445,7 @@ void update_halo_kernel(bool use_target, int x_min, int x_max, int y_min, int y_
       // DO k=y_min-depth,y_max+1+depth
 
       double *xvel1 = field.xvel1.data;
-#pragma omp target teams distribute parallel for simd clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector default(present) clover_use_target(use_target)
       for (int k = (y_min - depth + 1); k < (y_max + 1 + depth + 2); k++) {
         for (int j = 0; j < depth; ++j) {
           xvel1[(1 - j) + (k)*vels_wk_stride] = -xvel1[(1 + 2 + j) + (k)*vels_wk_stride];
@@ -455,7 +456,7 @@ void update_halo_kernel(bool use_target, int x_min, int x_max, int y_min, int y_
       // DO k=y_min-depth,y_max+1+depth
 
       double *xvel1 = field.xvel1.data;
-#pragma omp target teams distribute parallel for simd clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector default(present) clover_use_target(use_target)
       for (int k = (y_min - depth + 1); k < (y_max + 1 + depth + 2); k++) {
         for (int j = 0; j < depth; ++j) {
           xvel1[(x_max + 2 + 1 + j) + (k)*vels_wk_stride] = -xvel1[(x_max + 1 - j) + (k)*vels_wk_stride];
@@ -469,7 +470,7 @@ void update_halo_kernel(bool use_target, int x_min, int x_max, int y_min, int y_
       // DO j=x_min-depth,x_max+1+depth
 
       double *yvel0 = field.yvel0.data;
-#pragma omp target teams distribute parallel for simd clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector default(present) clover_use_target(use_target)
       for (int j = (x_min - depth + 1); j < (x_max + 1 + depth + 2); j++) {
         for (int k = 0; k < depth; ++k) {
           yvel0[j + (1 - k) * vels_wk_stride] = -yvel0[j + (1 + 2 + k) * vels_wk_stride];
@@ -480,7 +481,7 @@ void update_halo_kernel(bool use_target, int x_min, int x_max, int y_min, int y_
       // DO j=x_min-depth,x_max+1+depth
 
       double *yvel0 = field.yvel0.data;
-#pragma omp target teams distribute parallel for simd clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector default(present) clover_use_target(use_target)
       for (int j = (x_min - depth + 1); j < (x_max + 1 + depth + 2); j++) {
         for (int k = 0; k < depth; ++k) {
           yvel0[j + (y_max + 1 + 2 + k) * vels_wk_stride] = -yvel0[j + (y_max + 1 - k) * vels_wk_stride];
@@ -491,7 +492,7 @@ void update_halo_kernel(bool use_target, int x_min, int x_max, int y_min, int y_
       // DO k=y_min-depth,y_max+1+depth
 
       double *yvel0 = field.yvel0.data;
-#pragma omp target teams distribute parallel for simd clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector default(present) clover_use_target(use_target)
       for (int k = (y_min - depth + 1); k < (y_max + 1 + depth + 2); k++) {
         for (int j = 0; j < depth; ++j) {
           yvel0[(1 - j) + (k)*vels_wk_stride] = yvel0[(1 + 2 + j) + (k)*vels_wk_stride];
@@ -502,7 +503,7 @@ void update_halo_kernel(bool use_target, int x_min, int x_max, int y_min, int y_
       // DO k=y_min-depth,y_max+1+depth
 
       double *yvel0 = field.yvel0.data;
-#pragma omp target teams distribute parallel for simd clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector default(present) clover_use_target(use_target)
       for (int k = (y_min - depth + 1); k < (y_max + 1 + depth + 2); k++) {
         for (int j = 0; j < depth; ++j) {
           yvel0[(x_max + 2 + 1 + j) + (k)*vels_wk_stride] = yvel0[(x_max + 1 - j) + (k)*vels_wk_stride];
@@ -516,7 +517,7 @@ void update_halo_kernel(bool use_target, int x_min, int x_max, int y_min, int y_
       // DO j=x_min-depth,x_max+1+depth
 
       double *yvel1 = field.yvel1.data;
-#pragma omp target teams distribute parallel for simd clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector default(present) clover_use_target(use_target)
       for (int j = (x_min - depth + 1); j < (x_max + 1 + depth + 2); j++) {
         for (int k = 0; k < depth; ++k) {
           yvel1[j + (1 - k) * vels_wk_stride] = -yvel1[j + (1 + 2 + k) * vels_wk_stride];
@@ -527,7 +528,7 @@ void update_halo_kernel(bool use_target, int x_min, int x_max, int y_min, int y_
       // DO j=x_min-depth,x_max+1+depth
 
       double *yvel1 = field.yvel1.data;
-#pragma omp target teams distribute parallel for simd clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector default(present) clover_use_target(use_target)
       for (int j = (x_min - depth + 1); j < (x_max + 1 + depth + 2); j++) {
         for (int k = 0; k < depth; ++k) {
           yvel1[j + (y_max + 1 + 2 + k) * vels_wk_stride] = -yvel1[j + (y_max + 1 - k) * vels_wk_stride];
@@ -538,7 +539,7 @@ void update_halo_kernel(bool use_target, int x_min, int x_max, int y_min, int y_
       // DO k=y_min-depth,y_max+1+depth
 
       double *yvel1 = field.yvel1.data;
-#pragma omp target teams distribute parallel for simd clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector default(present) clover_use_target(use_target)
       for (int k = (y_min - depth + 1); k < (y_max + 1 + depth + 2); k++) {
         for (int j = 0; j < depth; ++j) {
           yvel1[(1 - j) + (k)*vels_wk_stride] = yvel1[(1 + 2 + j) + (k)*vels_wk_stride];
@@ -549,7 +550,7 @@ void update_halo_kernel(bool use_target, int x_min, int x_max, int y_min, int y_
       // DO k=y_min-depth,y_max+1+depth
 
       double *yvel1 = field.yvel1.data;
-#pragma omp target teams distribute parallel for simd clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector default(present) clover_use_target(use_target)
       for (int k = (y_min - depth + 1); k < (y_max + 1 + depth + 2); k++) {
         for (int j = 0; j < depth; ++j) {
           yvel1[(x_max + 2 + 1 + j) + (k)*vels_wk_stride] = yvel1[(x_max + 1 - j) + (k)*vels_wk_stride];
@@ -563,7 +564,7 @@ void update_halo_kernel(bool use_target, int x_min, int x_max, int y_min, int y_
       // DO j=x_min-depth,x_max+1+depth
 
       double *vol_flux_x = field.vol_flux_x.data;
-#pragma omp target teams distribute parallel for simd clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector default(present) clover_use_target(use_target)
       for (int j = (x_min - depth + 1); j < (x_max + 1 + depth + 2); j++) {
         for (int k = 0; k < depth; ++k) {
           vol_flux_x[j + (1 - k) * flux_x_stride] = vol_flux_x[j + (1 + 2 + k) * flux_x_stride];
@@ -574,7 +575,7 @@ void update_halo_kernel(bool use_target, int x_min, int x_max, int y_min, int y_
       // DO j=x_min-depth,x_max+1+depth
 
       double *vol_flux_x = field.vol_flux_x.data;
-#pragma omp target teams distribute parallel for simd clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector default(present) clover_use_target(use_target)
       for (int j = (x_min - depth + 1); j < (x_max + 1 + depth + 2); j++) {
         for (int k = 0; k < depth; ++k) {
           vol_flux_x[j + (y_max + 2 + k) * flux_x_stride] = vol_flux_x[j + (y_max - k) * flux_x_stride];
@@ -585,7 +586,7 @@ void update_halo_kernel(bool use_target, int x_min, int x_max, int y_min, int y_
       // DO k=y_min-depth,y_max+depth
 
       double *vol_flux_x = field.vol_flux_x.data;
-#pragma omp target teams distribute parallel for simd clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector default(present) clover_use_target(use_target)
       for (int k = (y_min - depth + 1); k < (y_max + depth + 2); k++) {
         for (int j = 0; j < depth; ++j) {
           vol_flux_x[(1 - j) + (k)*flux_x_stride] = -vol_flux_x[(1 + 2 + j) + (k)*flux_x_stride];
@@ -596,7 +597,7 @@ void update_halo_kernel(bool use_target, int x_min, int x_max, int y_min, int y_
       // DO k=y_min-depth,y_max+depth
 
       double *vol_flux_x = field.vol_flux_x.data;
-#pragma omp target teams distribute parallel for simd clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector default(present) clover_use_target(use_target)
       for (int k = (y_min - depth + 1); k < (y_max + depth + 2); k++) {
         for (int j = 0; j < depth; ++j) {
           vol_flux_x[(x_max + j + 1 + 2) + (k)*flux_x_stride] = -vol_flux_x[(x_max + 1 - j) + (k)*flux_x_stride];
@@ -610,7 +611,7 @@ void update_halo_kernel(bool use_target, int x_min, int x_max, int y_min, int y_
       // DO j=x_min-depth,x_max+1+depth
 
       double *mass_flux_x = field.mass_flux_x.data;
-#pragma omp target teams distribute parallel for simd clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector default(present) clover_use_target(use_target)
       for (int j = (x_min - depth + 1); j < (x_max + 1 + depth + 2); j++) {
         for (int k = 0; k < depth; ++k) {
           mass_flux_x[j + (1 - k) * flux_x_stride] = mass_flux_x[j + (1 + 2 + k) * flux_x_stride];
@@ -621,7 +622,7 @@ void update_halo_kernel(bool use_target, int x_min, int x_max, int y_min, int y_
       // DO j=x_min-depth,x_max+1+depth
 
       double *mass_flux_x = field.mass_flux_x.data;
-#pragma omp target teams distribute parallel for simd clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector default(present) clover_use_target(use_target)
       for (int j = (x_min - depth + 1); j < (x_max + 1 + depth + 2); j++) {
         for (int k = 0; k < depth; ++k) {
           mass_flux_x[j + (y_max + 2 + k) * flux_x_stride] = mass_flux_x[j + (y_max - k) * flux_x_stride];
@@ -632,7 +633,7 @@ void update_halo_kernel(bool use_target, int x_min, int x_max, int y_min, int y_
       // DO k=y_min-depth,y_max+depth
 
       double *mass_flux_x = field.mass_flux_x.data;
-#pragma omp target teams distribute parallel for simd clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector default(present) clover_use_target(use_target)
       for (int k = (y_min - depth + 1); k < (y_max + depth + 2); k++) {
         for (int j = 0; j < depth; ++j) {
           mass_flux_x[(1 - j) + (k)*flux_x_stride] = -mass_flux_x[(1 + 2 + j) + (k)*flux_x_stride];
@@ -643,7 +644,7 @@ void update_halo_kernel(bool use_target, int x_min, int x_max, int y_min, int y_
       // DO k=y_min-depth,y_max+depth
 
       double *mass_flux_x = field.mass_flux_x.data;
-#pragma omp target teams distribute parallel for simd clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector default(present) clover_use_target(use_target)
       for (int k = (y_min - depth + 1); k < (y_max + depth + 2); k++) {
         for (int j = 0; j < depth; ++j) {
           mass_flux_x[(x_max + j + 1 + 2) + (k)*flux_x_stride] = -mass_flux_x[(x_max + 1 - j) + (k)*flux_x_stride];
@@ -657,7 +658,7 @@ void update_halo_kernel(bool use_target, int x_min, int x_max, int y_min, int y_
       // DO j=x_min-depth,x_max+depth
 
       double *vol_flux_y = field.vol_flux_y.data;
-#pragma omp target teams distribute parallel for simd clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector default(present) clover_use_target(use_target)
       for (int j = (x_min - depth + 1); j < (x_max + depth + 2); j++) {
         for (int k = 0; k < depth; ++k) {
           vol_flux_y[j + (1 - k) * flux_y_stride] = -vol_flux_y[j + (1 + 2 + k) * flux_y_stride];
@@ -668,7 +669,7 @@ void update_halo_kernel(bool use_target, int x_min, int x_max, int y_min, int y_
       // DO j=x_min-depth,x_max+depth
 
       double *vol_flux_y = field.vol_flux_y.data;
-#pragma omp target teams distribute parallel for simd clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector default(present) clover_use_target(use_target)
       for (int j = (x_min - depth + 1); j < (x_max + depth + 2); j++) {
         for (int k = 0; k < depth; ++k) {
           vol_flux_y[j + (y_max + k + 1 + 2) * flux_y_stride] = -vol_flux_y[j + (y_max + 1 - k) * flux_y_stride];
@@ -679,7 +680,7 @@ void update_halo_kernel(bool use_target, int x_min, int x_max, int y_min, int y_
       // DO k=y_min-depth,y_max+1+depth
 
       double *vol_flux_y = field.vol_flux_y.data;
-#pragma omp target teams distribute parallel for simd clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector default(present) clover_use_target(use_target)
       for (int k = (y_min - depth + 1); k < (y_max + 1 + depth + 2); k++) {
         for (int j = 0; j < depth; ++j) {
           vol_flux_y[(1 - j) + (k)*flux_y_stride] = vol_flux_y[(1 + 2 + j) + (k)*flux_y_stride];
@@ -690,7 +691,7 @@ void update_halo_kernel(bool use_target, int x_min, int x_max, int y_min, int y_
       // DO k=y_min-depth,y_max+1+depth
 
       double *vol_flux_y = field.vol_flux_y.data;
-#pragma omp target teams distribute parallel for simd clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector default(present) clover_use_target(use_target)
       for (int k = (y_min - depth + 1); k < (y_max + 1 + depth + 2); k++) {
         for (int j = 0; j < depth; ++j) {
           vol_flux_y[(x_max + 2 + j) + (k)*flux_y_stride] = vol_flux_y[(x_max - j) + (k)*flux_y_stride];
@@ -704,7 +705,7 @@ void update_halo_kernel(bool use_target, int x_min, int x_max, int y_min, int y_
       // DO j=x_min-depth,x_max+depth
 
       double *mass_flux_y = field.mass_flux_y.data;
-#pragma omp target teams distribute parallel for simd clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector default(present) clover_use_target(use_target)
       for (int j = (x_min - depth + 1); j < (x_max + depth + 2); j++) {
         for (int k = 0; k < depth; ++k) {
           mass_flux_y[j + (1 - k) * flux_y_stride] = -mass_flux_y[j + (1 + 2 + k) * flux_y_stride];
@@ -715,7 +716,7 @@ void update_halo_kernel(bool use_target, int x_min, int x_max, int y_min, int y_
       // DO j=x_min-depth,x_max+depth
 
       double *mass_flux_y = field.mass_flux_y.data;
-#pragma omp target teams distribute parallel for simd clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector default(present) clover_use_target(use_target)
       for (int j = (x_min - depth + 1); j < (x_max + depth + 2); j++) {
         for (int k = 0; k < depth; ++k) {
           mass_flux_y[j + (y_max + k + 1 + 2) * flux_y_stride] = -mass_flux_y[j + (y_max + 1 - k) * flux_y_stride];
@@ -726,7 +727,7 @@ void update_halo_kernel(bool use_target, int x_min, int x_max, int y_min, int y_
       // DO k=y_min-depth,y_max+1+depth
 
       double *mass_flux_y = field.mass_flux_y.data;
-#pragma omp target teams distribute parallel for simd clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector default(present) clover_use_target(use_target)
       for (int k = (y_min - depth + 1); k < (y_max + 1 + depth + 2); k++) {
         for (int j = 0; j < depth; ++j) {
           mass_flux_y[(1 - j) + (k)*flux_y_stride] = mass_flux_y[(1 + 2 + j) + (k)*flux_y_stride];
@@ -737,7 +738,7 @@ void update_halo_kernel(bool use_target, int x_min, int x_max, int y_min, int y_
       // DO k=y_min-depth,y_max+1+depth
 
       double *mass_flux_y = field.mass_flux_y.data;
-#pragma omp target teams distribute parallel for simd clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector default(present) clover_use_target(use_target)
       for (int k = (y_min - depth + 1); k < (y_max + 1 + depth + 2); k++) {
         for (int j = 0; j < depth; ++j) {
           mass_flux_y[(x_max + 2 + j) + (k)*flux_y_stride] = mass_flux_y[(x_max - j) + (k)*flux_y_stride];

--- a/src/acc/update_halo.cpp
+++ b/src/acc/update_halo.cpp
@@ -46,7 +46,8 @@ void update_halo_kernel(bool use_target, int x_min, int x_max, int y_min, int y_
 
       double *density0 = field.density0.data;
 
-#pragma acc parallel loop gang worker vector default(present) clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector clover_use_target(use_target) \
+  present(density0[ : field.density0.N()])
       for (int j = (x_min - depth + 1); j < (x_max + depth + 2); j++) {
         for (int k = 0; k < depth; ++k) {
           density0[j + (1 - k) * base_stride] = density0[j + (2 + k) * base_stride];
@@ -57,7 +58,8 @@ void update_halo_kernel(bool use_target, int x_min, int x_max, int y_min, int y_
       // DO j=x_min-depth,x_max+depth
 
       double *density0 = field.density0.data;
-#pragma acc parallel loop gang worker vector default(present) clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector clover_use_target(use_target) \
+  present(density0[ : field.density0.N()])
       for (int j = (x_min - depth + 1); j < (x_max + depth + 2); j++) {
         for (int k = 0; k < depth; ++k) {
           density0[j + (y_max + 2 + k) * base_stride] = density0[j + (y_max + 1 - k) * base_stride];
@@ -68,7 +70,8 @@ void update_halo_kernel(bool use_target, int x_min, int x_max, int y_min, int y_
       // DO k=y_min-depth,y_max+depth
 
       double *density0 = field.density0.data;
-#pragma acc parallel loop gang worker vector default(present) clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector clover_use_target(use_target) \
+  present(density0[ : field.density0.N()])
       for (int k = (y_min - depth + 1); k < (y_max + depth + 2); k++) {
         for (int j = 0; j < depth; ++j) {
           density0[(1 - j) + (k)*base_stride] = density0[(2 + j) + (k)*base_stride];
@@ -79,7 +82,8 @@ void update_halo_kernel(bool use_target, int x_min, int x_max, int y_min, int y_
       // DO k=y_min-depth,y_max+depth
 
       double *density0 = field.density0.data;
-#pragma acc parallel loop gang worker vector default(present) clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector clover_use_target(use_target) \
+  present(density0[ : field.density0.N()])
       for (int k = (y_min - depth + 1); k < (y_max + depth + 2); k++) {
         for (int j = 0; j < depth; ++j) {
           density0[(x_max + 2 + j) + (k)*base_stride] = density0[(x_max + 1 - j) + (k)*base_stride];
@@ -93,7 +97,8 @@ void update_halo_kernel(bool use_target, int x_min, int x_max, int y_min, int y_
       // DO k=y_min-depth,y_max+depth
 
       double *density1 = field.density1.data;
-#pragma acc parallel loop gang worker vector default(present) clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector clover_use_target(use_target) \
+  present(density1[ : field.density1.N()])
       for (int j = (x_min - depth + 1); j < (x_max + depth + 2); j++) {
         for (int k = 0; k < depth; ++k) {
           density1[j + (1 - k) * base_stride] = density1[j + (2 + k) * base_stride];
@@ -104,7 +109,8 @@ void update_halo_kernel(bool use_target, int x_min, int x_max, int y_min, int y_
       // DO j=x_min-depth,x_max+depth
 
       double *density1 = field.density1.data;
-#pragma acc parallel loop gang worker vector default(present) clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector clover_use_target(use_target) \
+  present(density1[ : field.density1.N()])
       for (int j = (x_min - depth + 1); j < (x_max + depth + 2); j++) {
         for (int k = 0; k < depth; ++k) {
           density1[j + (y_max + 2 + k) * base_stride] = density1[j + (y_max + 1 - k) * base_stride];
@@ -115,7 +121,8 @@ void update_halo_kernel(bool use_target, int x_min, int x_max, int y_min, int y_
       // DO k=y_min-depth,y_max+depth
 
       double *density1 = field.density1.data;
-#pragma acc parallel loop gang worker vector default(present) clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector clover_use_target(use_target) \
+  present(density1[ : field.density1.N()])
       for (int k = (y_min - depth + 1); k < (y_max + depth + 2); k++) {
         for (int j = 0; j < depth; ++j) {
           density1[(1 - j) + (k)*base_stride] = density1[(2 + j) + (k)*base_stride];
@@ -126,7 +133,8 @@ void update_halo_kernel(bool use_target, int x_min, int x_max, int y_min, int y_
       // DO k=y_min-depth,y_max+depth
 
       double *density1 = field.density1.data;
-#pragma acc parallel loop gang worker vector default(present) clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector clover_use_target(use_target) \
+  present(density1[ : field.density1.N()])
       for (int k = (y_min - depth + 1); k < (y_max + depth + 2); k++) {
         for (int j = 0; j < depth; ++j) {
           density1[(x_max + 2 + j) + (k)*base_stride] = density1[(x_max + 1 - j) + (k)*base_stride];
@@ -140,7 +148,8 @@ void update_halo_kernel(bool use_target, int x_min, int x_max, int y_min, int y_
       //  DO j=x_min-depth,x_max+depth
 
       double *energy0 = field.energy0.data;
-#pragma acc parallel loop gang worker vector default(present) clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector clover_use_target(use_target) \
+  present(energy0[ : field.energy0.N()])
       for (int j = (x_min - depth + 1); j < (x_max + depth + 2); j++) {
         for (int k = 0; k < depth; ++k) {
           energy0[j + (1 - k) * base_stride] = energy0[j + (2 + k) * base_stride];
@@ -151,7 +160,8 @@ void update_halo_kernel(bool use_target, int x_min, int x_max, int y_min, int y_
       // DO j=x_min-depth,x_max+depth
 
       double *energy0 = field.energy0.data;
-#pragma acc parallel loop gang worker vector default(present) clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector clover_use_target(use_target) \
+  present(energy0[ : field.energy0.N()])
       for (int j = (x_min - depth + 1); j < (x_max + depth + 2); j++) {
         for (int k = 0; k < depth; ++k) {
           energy0[j + (y_max + 2 + k) * base_stride] = energy0[j + (y_max + 1 - k) * base_stride];
@@ -162,7 +172,8 @@ void update_halo_kernel(bool use_target, int x_min, int x_max, int y_min, int y_
       // DO k=y_min-depth,y_max+depth
 
       double *energy0 = field.energy0.data;
-#pragma acc parallel loop gang worker vector default(present) clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector clover_use_target(use_target) \
+  present(energy0[ : field.energy0.N()])
       for (int k = (y_min - depth + 1); k < (y_max + depth + 2); k++) {
         for (int j = 0; j < depth; ++j) {
           energy0[(1 - j) + (k)*base_stride] = energy0[(2 + j) + (k)*base_stride];
@@ -173,7 +184,8 @@ void update_halo_kernel(bool use_target, int x_min, int x_max, int y_min, int y_
       // DO k=y_min-depth,y_max+depth
 
       double *energy0 = field.energy0.data;
-#pragma acc parallel loop gang worker vector default(present) clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector clover_use_target(use_target) \
+  present(energy0[ : field.energy0.N()])
       for (int k = (y_min - depth + 1); k < (y_max + depth + 2); k++) {
         for (int j = 0; j < depth; ++j) {
           energy0[(x_max + 2 + j) + (k)*base_stride] = energy0[(x_max + 1 - j) + (k)*base_stride];
@@ -187,7 +199,8 @@ void update_halo_kernel(bool use_target, int x_min, int x_max, int y_min, int y_
       // DO j=x_min-depth,x_max+depth
 
       double *energy1 = field.energy1.data;
-#pragma acc parallel loop gang worker vector default(present) clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector clover_use_target(use_target) \
+  present(energy1[ : field.energy1.N()])
       for (int j = (x_min - depth + 1); j < (x_max + depth + 2); j++) {
         for (int k = 0; k < depth; ++k) {
           energy1[j + (1 - k) * base_stride] = energy1[j + (2 + k) * base_stride];
@@ -198,7 +211,8 @@ void update_halo_kernel(bool use_target, int x_min, int x_max, int y_min, int y_
       // DO j=x_min-depth,x_max+depth
 
       double *energy1 = field.energy1.data;
-#pragma acc parallel loop gang worker vector default(present) clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector clover_use_target(use_target) \
+  present(energy1[ : field.energy1.N()])
       for (int j = (x_min - depth + 1); j < (x_max + depth + 2); j++) {
         for (int k = 0; k < depth; ++k) {
           energy1[j + (y_max + 2 + k) * base_stride] = energy1[j + (y_max + 1 - k) * base_stride];
@@ -209,7 +223,8 @@ void update_halo_kernel(bool use_target, int x_min, int x_max, int y_min, int y_
       // DO k=y_min-depth,y_max+depth
 
       double *energy1 = field.energy1.data;
-#pragma acc parallel loop gang worker vector default(present) clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector clover_use_target(use_target) \
+  present(energy1[ : field.energy1.N()])
       for (int k = (y_min - depth + 1); k < (y_max + depth + 2); k++) {
         for (int j = 0; j < depth; ++j) {
           energy1[(1 - j) + (k)*base_stride] = energy1[(2 + j) + (k)*base_stride];
@@ -220,7 +235,8 @@ void update_halo_kernel(bool use_target, int x_min, int x_max, int y_min, int y_
       // DO k=y_min-depth,y_max+depth
 
       double *energy1 = field.energy1.data;
-#pragma acc parallel loop gang worker vector default(present) clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector clover_use_target(use_target) \
+  present(energy1[ : field.energy1.N()])
       for (int k = (y_min - depth + 1); k < (y_max + depth + 2); k++) {
         for (int j = 0; j < depth; ++j) {
           energy1[(x_max + 2 + j) + (k)*base_stride] = energy1[(x_max + 1 - j) + (k)*base_stride];
@@ -234,7 +250,8 @@ void update_halo_kernel(bool use_target, int x_min, int x_max, int y_min, int y_
       // DO j=x_min-depth,x_max+depth
 
       double *pressure = field.pressure.data;
-#pragma acc parallel loop gang worker vector default(present) clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector clover_use_target(use_target) \
+  present(pressure[ : field.pressure.N()])
       for (int j = (x_min - depth + 1); j < (x_max + depth + 2); j++) {
         for (int k = 0; k < depth; ++k) {
           pressure[j + (1 - k) * base_stride] = pressure[j + (2 + k) * base_stride];
@@ -245,7 +262,8 @@ void update_halo_kernel(bool use_target, int x_min, int x_max, int y_min, int y_
       // DO j=x_min-depth,x_max+depth
 
       double *pressure = field.pressure.data;
-#pragma acc parallel loop gang worker vector default(present) clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector clover_use_target(use_target) \
+  present(pressure[ : field.pressure.N()])
       for (int j = (x_min - depth + 1); j < (x_max + depth + 2); j++) {
         for (int k = 0; k < depth; ++k) {
           pressure[j + (y_max + 2 + k) * base_stride] = pressure[j + (y_max + 1 - k) * base_stride];
@@ -256,7 +274,8 @@ void update_halo_kernel(bool use_target, int x_min, int x_max, int y_min, int y_
       // DO k=y_min-depth,y_max+depth
 
       double *pressure = field.pressure.data;
-#pragma acc parallel loop gang worker vector default(present) clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector clover_use_target(use_target) \
+  present(pressure[ : field.pressure.N()])
       for (int k = (y_min - depth + 1); k < (y_max + depth + 2); k++) {
         for (int j = 0; j < depth; ++j) {
           pressure[(1 - j) + (k)*base_stride] = pressure[(2 + j) + (k)*base_stride];
@@ -267,7 +286,8 @@ void update_halo_kernel(bool use_target, int x_min, int x_max, int y_min, int y_
       // DO k=y_min-depth,y_max+depth
 
       double *pressure = field.pressure.data;
-#pragma acc parallel loop gang worker vector default(present) clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector clover_use_target(use_target) \
+  present(pressure[ : field.pressure.N()])
       for (int k = (y_min - depth + 1); k < (y_max + depth + 2); k++) {
         for (int j = 0; j < depth; ++j) {
           pressure[(x_max + 2 + j) + (k)*base_stride] = pressure[(x_max + 1 - j) + (k)*base_stride];
@@ -281,7 +301,8 @@ void update_halo_kernel(bool use_target, int x_min, int x_max, int y_min, int y_
       // DO j=x_min-depth,x_max+depth
 
       double *viscosity = field.viscosity.data;
-#pragma acc parallel loop gang worker vector default(present) clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector clover_use_target(use_target) \
+  present(viscosity[ : field.viscosity.N()])
       for (int j = (x_min - depth + 1); j < (x_max + depth + 2); j++) {
         for (int k = 0; k < depth; ++k) {
           viscosity[j + (1 - k) * base_stride] = viscosity[j + (2 + k) * base_stride];
@@ -292,7 +313,8 @@ void update_halo_kernel(bool use_target, int x_min, int x_max, int y_min, int y_
       // DO j=x_min-depth,x_max+depth
 
       double *viscosity = field.viscosity.data;
-#pragma acc parallel loop gang worker vector default(present) clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector clover_use_target(use_target) \
+  present(viscosity[ : field.viscosity.N()])
       for (int j = (x_min - depth + 1); j < (x_max + depth + 2); j++) {
         for (int k = 0; k < depth; ++k) {
           viscosity[j + (y_max + 2 + k) * base_stride] = viscosity[j + (y_max + 1 - k) * base_stride];
@@ -303,7 +325,8 @@ void update_halo_kernel(bool use_target, int x_min, int x_max, int y_min, int y_
       // DO k=y_min-depth,y_max+depth
 
       double *viscosity = field.viscosity.data;
-#pragma acc parallel loop gang worker vector default(present) clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector clover_use_target(use_target) \
+  present(viscosity[ : field.viscosity.N()])
       for (int k = (y_min - depth + 1); k < (y_max + depth + 2); k++) {
         for (int j = 0; j < depth; ++j) {
           viscosity[(1 - j) + (k)*base_stride] = viscosity[(2 + j) + (k)*base_stride];
@@ -314,7 +337,8 @@ void update_halo_kernel(bool use_target, int x_min, int x_max, int y_min, int y_
       // DO k=y_min-depth,y_max+depth
 
       double *viscosity = field.viscosity.data;
-#pragma acc parallel loop gang worker vector default(present) clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector clover_use_target(use_target) \
+  present(viscosity[ : field.viscosity.N()])
       for (int k = (y_min - depth + 1); k < (y_max + depth + 2); k++) {
         for (int j = 0; j < depth; ++j) {
           viscosity[(x_max + 2 + j) + (k)*base_stride] = viscosity[(x_max + 1 - j) + (k)*base_stride];
@@ -328,7 +352,8 @@ void update_halo_kernel(bool use_target, int x_min, int x_max, int y_min, int y_
       // DO j=x_min-depth,x_max+depth
 
       double *soundspeed = field.soundspeed.data;
-#pragma acc parallel loop gang worker vector default(present) clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector clover_use_target(use_target) \
+  present(soundspeed[ : field.soundspeed.N()])
       for (int j = (x_min - depth + 1); j < (x_max + depth + 2); j++) {
         for (int k = 0; k < depth; ++k) {
           soundspeed[j + (1 - k) * base_stride] = soundspeed[j + (+k) * base_stride];
@@ -339,7 +364,8 @@ void update_halo_kernel(bool use_target, int x_min, int x_max, int y_min, int y_
       // DO j=x_min-depth,x_max+depth
 
       double *soundspeed = field.soundspeed.data;
-#pragma acc parallel loop gang worker vector default(present) clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector clover_use_target(use_target) \
+  present(soundspeed[ : field.soundspeed.N()])
       for (int j = (x_min - depth + 1); j < (x_max + depth + 2); j++) {
         for (int k = 0; k < depth; ++k) {
           soundspeed[j + (y_max + 2 + k) * base_stride] = soundspeed[j + (y_max + 1 - k) * base_stride];
@@ -350,7 +376,8 @@ void update_halo_kernel(bool use_target, int x_min, int x_max, int y_min, int y_
       //  DO k=y_min-depth,y_max+depth
 
       double *soundspeed = field.soundspeed.data;
-#pragma acc parallel loop gang worker vector default(present) clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector clover_use_target(use_target) \
+  present(soundspeed[ : field.soundspeed.N()])
       for (int k = (y_min - depth + 1); k < (y_max + depth + 2); k++) {
         for (int j = 0; j < depth; ++j) {
           soundspeed[(1 - j) + (k)*base_stride] = soundspeed[(2 + j) + (k)*base_stride];
@@ -361,7 +388,8 @@ void update_halo_kernel(bool use_target, int x_min, int x_max, int y_min, int y_
       //  DO k=y_min-depth,y_max+depth
 
       double *soundspeed = field.soundspeed.data;
-#pragma acc parallel loop gang worker vector default(present) clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector clover_use_target(use_target) \
+  present(soundspeed[ : field.soundspeed.N()])
       for (int k = (y_min - depth + 1); k < (y_max + depth + 2); k++) {
         for (int j = 0; j < depth; ++j) {
           soundspeed[(x_max + 2 + j) + (k)*base_stride] = soundspeed[(x_max + 1 - j) + (k)*base_stride];
@@ -376,7 +404,8 @@ void update_halo_kernel(bool use_target, int x_min, int x_max, int y_min, int y_
       // DO j=x_min-depth,x_max+1+depth
 
       double *xvel0 = field.xvel0.data;
-#pragma acc parallel loop gang worker vector default(present) clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector clover_use_target(use_target) \
+  present(xvel0[ : field.xvel0.N()])
       for (int j = (x_min - depth + 1); j < (x_max + 1 + depth + 2); j++) {
         for (int k = 0; k < depth; ++k) {
           xvel0[j + (1 - k) * vels_wk_stride] = xvel0[j + (1 + 2 + k) * vels_wk_stride];
@@ -387,7 +416,8 @@ void update_halo_kernel(bool use_target, int x_min, int x_max, int y_min, int y_
       // DO j=x_min-depth,x_max+1+depth
 
       double *xvel0 = field.xvel0.data;
-#pragma acc parallel loop gang worker vector default(present) clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector clover_use_target(use_target) \
+  present(xvel0[ : field.xvel0.N()])
       for (int j = (x_min - depth + 1); j < (x_max + 1 + depth + 2); j++) {
         for (int k = 0; k < depth; ++k) {
           xvel0[j + (y_max + 1 + 2 + k) * vels_wk_stride] = xvel0[j + (y_max + 1 - k) * vels_wk_stride];
@@ -398,7 +428,8 @@ void update_halo_kernel(bool use_target, int x_min, int x_max, int y_min, int y_
       // DO k=y_min-depth,y_max+1+depth
 
       double *xvel0 = field.xvel0.data;
-#pragma acc parallel loop gang worker vector default(present) clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector clover_use_target(use_target) \
+  present(xvel0[ : field.xvel0.N()])
       for (int k = (y_min - depth + 1); k < (y_max + 1 + depth + 2); k++) {
         for (int j = 0; j < depth; ++j) {
           xvel0[(1 - j) + (k)*vels_wk_stride] = -xvel0[(1 + 2 + j) + (k)*vels_wk_stride];
@@ -409,7 +440,8 @@ void update_halo_kernel(bool use_target, int x_min, int x_max, int y_min, int y_
       // DO k=y_min-depth,y_max+1+depth
 
       double *xvel0 = field.xvel0.data;
-#pragma acc parallel loop gang worker vector default(present) clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector clover_use_target(use_target) \
+  present(xvel0[ : field.xvel0.N()])
       for (int k = (y_min - depth + 1); k < (y_max + 1 + depth + 2); k++) {
         for (int j = 0; j < depth; ++j) {
           xvel0[(x_max + 2 + 1 + j) + (k)*vels_wk_stride] = -xvel0[(x_max + 1 - j) + (k)*vels_wk_stride];
@@ -423,7 +455,8 @@ void update_halo_kernel(bool use_target, int x_min, int x_max, int y_min, int y_
       // DO j=x_min-depth,x_max+1+depth
 
       double *xvel1 = field.xvel1.data;
-#pragma acc parallel loop gang worker vector default(present) clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector clover_use_target(use_target) \
+  present(xvel1[ : field.xvel1.N()])
       for (int j = (x_min - depth + 1); j < (x_max + 1 + depth + 2); j++) {
         for (int k = 0; k < depth; ++k) {
           xvel1[j + (1 - k) * vels_wk_stride] = xvel1[j + (1 + 2 + k) * vels_wk_stride];
@@ -434,7 +467,8 @@ void update_halo_kernel(bool use_target, int x_min, int x_max, int y_min, int y_
       // DO j=x_min-depth,x_max+1+depth
 
       double *xvel1 = field.xvel1.data;
-#pragma acc parallel loop gang worker vector default(present) clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector clover_use_target(use_target) \
+  present(xvel1[ : field.xvel1.N()])
       for (int j = (x_min - depth + 1); j < (x_max + 1 + depth + 2); j++) {
         for (int k = 0; k < depth; ++k) {
           xvel1[j + (y_max + 1 + 2 + k) * vels_wk_stride] = xvel1[j + (y_max + 1 - k) * vels_wk_stride];
@@ -445,7 +479,8 @@ void update_halo_kernel(bool use_target, int x_min, int x_max, int y_min, int y_
       // DO k=y_min-depth,y_max+1+depth
 
       double *xvel1 = field.xvel1.data;
-#pragma acc parallel loop gang worker vector default(present) clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector clover_use_target(use_target) \
+  present(xvel1[ : field.xvel1.N()])
       for (int k = (y_min - depth + 1); k < (y_max + 1 + depth + 2); k++) {
         for (int j = 0; j < depth; ++j) {
           xvel1[(1 - j) + (k)*vels_wk_stride] = -xvel1[(1 + 2 + j) + (k)*vels_wk_stride];
@@ -456,7 +491,8 @@ void update_halo_kernel(bool use_target, int x_min, int x_max, int y_min, int y_
       // DO k=y_min-depth,y_max+1+depth
 
       double *xvel1 = field.xvel1.data;
-#pragma acc parallel loop gang worker vector default(present) clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector clover_use_target(use_target) \
+  present(xvel1[ : field.xvel1.N()])
       for (int k = (y_min - depth + 1); k < (y_max + 1 + depth + 2); k++) {
         for (int j = 0; j < depth; ++j) {
           xvel1[(x_max + 2 + 1 + j) + (k)*vels_wk_stride] = -xvel1[(x_max + 1 - j) + (k)*vels_wk_stride];
@@ -470,7 +506,8 @@ void update_halo_kernel(bool use_target, int x_min, int x_max, int y_min, int y_
       // DO j=x_min-depth,x_max+1+depth
 
       double *yvel0 = field.yvel0.data;
-#pragma acc parallel loop gang worker vector default(present) clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector clover_use_target(use_target) \
+  present(yvel0[ : field.yvel0.N()])
       for (int j = (x_min - depth + 1); j < (x_max + 1 + depth + 2); j++) {
         for (int k = 0; k < depth; ++k) {
           yvel0[j + (1 - k) * vels_wk_stride] = -yvel0[j + (1 + 2 + k) * vels_wk_stride];
@@ -481,7 +518,8 @@ void update_halo_kernel(bool use_target, int x_min, int x_max, int y_min, int y_
       // DO j=x_min-depth,x_max+1+depth
 
       double *yvel0 = field.yvel0.data;
-#pragma acc parallel loop gang worker vector default(present) clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector clover_use_target(use_target) \
+  present(yvel0[ : field.yvel0.N()])
       for (int j = (x_min - depth + 1); j < (x_max + 1 + depth + 2); j++) {
         for (int k = 0; k < depth; ++k) {
           yvel0[j + (y_max + 1 + 2 + k) * vels_wk_stride] = -yvel0[j + (y_max + 1 - k) * vels_wk_stride];
@@ -492,7 +530,8 @@ void update_halo_kernel(bool use_target, int x_min, int x_max, int y_min, int y_
       // DO k=y_min-depth,y_max+1+depth
 
       double *yvel0 = field.yvel0.data;
-#pragma acc parallel loop gang worker vector default(present) clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector clover_use_target(use_target) \
+  present(yvel0[ : field.yvel0.N()])
       for (int k = (y_min - depth + 1); k < (y_max + 1 + depth + 2); k++) {
         for (int j = 0; j < depth; ++j) {
           yvel0[(1 - j) + (k)*vels_wk_stride] = yvel0[(1 + 2 + j) + (k)*vels_wk_stride];
@@ -503,7 +542,8 @@ void update_halo_kernel(bool use_target, int x_min, int x_max, int y_min, int y_
       // DO k=y_min-depth,y_max+1+depth
 
       double *yvel0 = field.yvel0.data;
-#pragma acc parallel loop gang worker vector default(present) clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector clover_use_target(use_target) \
+  present(yvel0[ : field.yvel0.N()])
       for (int k = (y_min - depth + 1); k < (y_max + 1 + depth + 2); k++) {
         for (int j = 0; j < depth; ++j) {
           yvel0[(x_max + 2 + 1 + j) + (k)*vels_wk_stride] = yvel0[(x_max + 1 - j) + (k)*vels_wk_stride];
@@ -517,7 +557,8 @@ void update_halo_kernel(bool use_target, int x_min, int x_max, int y_min, int y_
       // DO j=x_min-depth,x_max+1+depth
 
       double *yvel1 = field.yvel1.data;
-#pragma acc parallel loop gang worker vector default(present) clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector clover_use_target(use_target) \
+  present(yvel1[ : field.yvel1.N()])
       for (int j = (x_min - depth + 1); j < (x_max + 1 + depth + 2); j++) {
         for (int k = 0; k < depth; ++k) {
           yvel1[j + (1 - k) * vels_wk_stride] = -yvel1[j + (1 + 2 + k) * vels_wk_stride];
@@ -528,7 +569,8 @@ void update_halo_kernel(bool use_target, int x_min, int x_max, int y_min, int y_
       // DO j=x_min-depth,x_max+1+depth
 
       double *yvel1 = field.yvel1.data;
-#pragma acc parallel loop gang worker vector default(present) clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector clover_use_target(use_target) \
+  present(yvel1[ : field.yvel1.N()])
       for (int j = (x_min - depth + 1); j < (x_max + 1 + depth + 2); j++) {
         for (int k = 0; k < depth; ++k) {
           yvel1[j + (y_max + 1 + 2 + k) * vels_wk_stride] = -yvel1[j + (y_max + 1 - k) * vels_wk_stride];
@@ -539,7 +581,8 @@ void update_halo_kernel(bool use_target, int x_min, int x_max, int y_min, int y_
       // DO k=y_min-depth,y_max+1+depth
 
       double *yvel1 = field.yvel1.data;
-#pragma acc parallel loop gang worker vector default(present) clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector clover_use_target(use_target) \
+  present(yvel1[ : field.yvel1.N()])
       for (int k = (y_min - depth + 1); k < (y_max + 1 + depth + 2); k++) {
         for (int j = 0; j < depth; ++j) {
           yvel1[(1 - j) + (k)*vels_wk_stride] = yvel1[(1 + 2 + j) + (k)*vels_wk_stride];
@@ -550,7 +593,8 @@ void update_halo_kernel(bool use_target, int x_min, int x_max, int y_min, int y_
       // DO k=y_min-depth,y_max+1+depth
 
       double *yvel1 = field.yvel1.data;
-#pragma acc parallel loop gang worker vector default(present) clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector clover_use_target(use_target) \
+  present(yvel1[ : field.yvel1.N()])
       for (int k = (y_min - depth + 1); k < (y_max + 1 + depth + 2); k++) {
         for (int j = 0; j < depth; ++j) {
           yvel1[(x_max + 2 + 1 + j) + (k)*vels_wk_stride] = yvel1[(x_max + 1 - j) + (k)*vels_wk_stride];
@@ -564,7 +608,8 @@ void update_halo_kernel(bool use_target, int x_min, int x_max, int y_min, int y_
       // DO j=x_min-depth,x_max+1+depth
 
       double *vol_flux_x = field.vol_flux_x.data;
-#pragma acc parallel loop gang worker vector default(present) clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector clover_use_target(use_target) \
+  present(vol_flux_x[ : field.vol_flux_x.N()])
       for (int j = (x_min - depth + 1); j < (x_max + 1 + depth + 2); j++) {
         for (int k = 0; k < depth; ++k) {
           vol_flux_x[j + (1 - k) * flux_x_stride] = vol_flux_x[j + (1 + 2 + k) * flux_x_stride];
@@ -575,7 +620,8 @@ void update_halo_kernel(bool use_target, int x_min, int x_max, int y_min, int y_
       // DO j=x_min-depth,x_max+1+depth
 
       double *vol_flux_x = field.vol_flux_x.data;
-#pragma acc parallel loop gang worker vector default(present) clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector clover_use_target(use_target) \
+  present(vol_flux_x[ : field.vol_flux_x.N()])
       for (int j = (x_min - depth + 1); j < (x_max + 1 + depth + 2); j++) {
         for (int k = 0; k < depth; ++k) {
           vol_flux_x[j + (y_max + 2 + k) * flux_x_stride] = vol_flux_x[j + (y_max - k) * flux_x_stride];
@@ -586,7 +632,8 @@ void update_halo_kernel(bool use_target, int x_min, int x_max, int y_min, int y_
       // DO k=y_min-depth,y_max+depth
 
       double *vol_flux_x = field.vol_flux_x.data;
-#pragma acc parallel loop gang worker vector default(present) clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector clover_use_target(use_target) \
+  present(vol_flux_x[ : field.vol_flux_x.N()])
       for (int k = (y_min - depth + 1); k < (y_max + depth + 2); k++) {
         for (int j = 0; j < depth; ++j) {
           vol_flux_x[(1 - j) + (k)*flux_x_stride] = -vol_flux_x[(1 + 2 + j) + (k)*flux_x_stride];
@@ -597,7 +644,8 @@ void update_halo_kernel(bool use_target, int x_min, int x_max, int y_min, int y_
       // DO k=y_min-depth,y_max+depth
 
       double *vol_flux_x = field.vol_flux_x.data;
-#pragma acc parallel loop gang worker vector default(present) clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector clover_use_target(use_target) \
+  present(vol_flux_x[ : field.vol_flux_x.N()])
       for (int k = (y_min - depth + 1); k < (y_max + depth + 2); k++) {
         for (int j = 0; j < depth; ++j) {
           vol_flux_x[(x_max + j + 1 + 2) + (k)*flux_x_stride] = -vol_flux_x[(x_max + 1 - j) + (k)*flux_x_stride];
@@ -611,7 +659,8 @@ void update_halo_kernel(bool use_target, int x_min, int x_max, int y_min, int y_
       // DO j=x_min-depth,x_max+1+depth
 
       double *mass_flux_x = field.mass_flux_x.data;
-#pragma acc parallel loop gang worker vector default(present) clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector clover_use_target(use_target) \
+  present(mass_flux_x[ : field.mass_flux_x.N()])
       for (int j = (x_min - depth + 1); j < (x_max + 1 + depth + 2); j++) {
         for (int k = 0; k < depth; ++k) {
           mass_flux_x[j + (1 - k) * flux_x_stride] = mass_flux_x[j + (1 + 2 + k) * flux_x_stride];
@@ -622,7 +671,8 @@ void update_halo_kernel(bool use_target, int x_min, int x_max, int y_min, int y_
       // DO j=x_min-depth,x_max+1+depth
 
       double *mass_flux_x = field.mass_flux_x.data;
-#pragma acc parallel loop gang worker vector default(present) clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector clover_use_target(use_target) \
+  present(mass_flux_x[ : field.vol_flux_x.N()])
       for (int j = (x_min - depth + 1); j < (x_max + 1 + depth + 2); j++) {
         for (int k = 0; k < depth; ++k) {
           mass_flux_x[j + (y_max + 2 + k) * flux_x_stride] = mass_flux_x[j + (y_max - k) * flux_x_stride];
@@ -633,7 +683,8 @@ void update_halo_kernel(bool use_target, int x_min, int x_max, int y_min, int y_
       // DO k=y_min-depth,y_max+depth
 
       double *mass_flux_x = field.mass_flux_x.data;
-#pragma acc parallel loop gang worker vector default(present) clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector clover_use_target(use_target) \
+  present(mass_flux_x[ : field.vol_flux_x.N()])
       for (int k = (y_min - depth + 1); k < (y_max + depth + 2); k++) {
         for (int j = 0; j < depth; ++j) {
           mass_flux_x[(1 - j) + (k)*flux_x_stride] = -mass_flux_x[(1 + 2 + j) + (k)*flux_x_stride];
@@ -644,7 +695,8 @@ void update_halo_kernel(bool use_target, int x_min, int x_max, int y_min, int y_
       // DO k=y_min-depth,y_max+depth
 
       double *mass_flux_x = field.mass_flux_x.data;
-#pragma acc parallel loop gang worker vector default(present) clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector clover_use_target(use_target) \
+  present(mass_flux_x[ : field.vol_flux_x.N()])
       for (int k = (y_min - depth + 1); k < (y_max + depth + 2); k++) {
         for (int j = 0; j < depth; ++j) {
           mass_flux_x[(x_max + j + 1 + 2) + (k)*flux_x_stride] = -mass_flux_x[(x_max + 1 - j) + (k)*flux_x_stride];
@@ -658,7 +710,8 @@ void update_halo_kernel(bool use_target, int x_min, int x_max, int y_min, int y_
       // DO j=x_min-depth,x_max+depth
 
       double *vol_flux_y = field.vol_flux_y.data;
-#pragma acc parallel loop gang worker vector default(present) clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector clover_use_target(use_target) \
+  present(vol_flux_y[ : field.vol_flux_y.N()])
       for (int j = (x_min - depth + 1); j < (x_max + depth + 2); j++) {
         for (int k = 0; k < depth; ++k) {
           vol_flux_y[j + (1 - k) * flux_y_stride] = -vol_flux_y[j + (1 + 2 + k) * flux_y_stride];
@@ -669,7 +722,8 @@ void update_halo_kernel(bool use_target, int x_min, int x_max, int y_min, int y_
       // DO j=x_min-depth,x_max+depth
 
       double *vol_flux_y = field.vol_flux_y.data;
-#pragma acc parallel loop gang worker vector default(present) clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector clover_use_target(use_target) \
+  present(vol_flux_y[ : field.vol_flux_y.N()])
       for (int j = (x_min - depth + 1); j < (x_max + depth + 2); j++) {
         for (int k = 0; k < depth; ++k) {
           vol_flux_y[j + (y_max + k + 1 + 2) * flux_y_stride] = -vol_flux_y[j + (y_max + 1 - k) * flux_y_stride];
@@ -680,7 +734,8 @@ void update_halo_kernel(bool use_target, int x_min, int x_max, int y_min, int y_
       // DO k=y_min-depth,y_max+1+depth
 
       double *vol_flux_y = field.vol_flux_y.data;
-#pragma acc parallel loop gang worker vector default(present) clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector clover_use_target(use_target) \
+  present(vol_flux_y[ : field.vol_flux_y.N()])
       for (int k = (y_min - depth + 1); k < (y_max + 1 + depth + 2); k++) {
         for (int j = 0; j < depth; ++j) {
           vol_flux_y[(1 - j) + (k)*flux_y_stride] = vol_flux_y[(1 + 2 + j) + (k)*flux_y_stride];
@@ -691,7 +746,8 @@ void update_halo_kernel(bool use_target, int x_min, int x_max, int y_min, int y_
       // DO k=y_min-depth,y_max+1+depth
 
       double *vol_flux_y = field.vol_flux_y.data;
-#pragma acc parallel loop gang worker vector default(present) clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector clover_use_target(use_target) \
+  present(vol_flux_y[ : field.vol_flux_y.N()])
       for (int k = (y_min - depth + 1); k < (y_max + 1 + depth + 2); k++) {
         for (int j = 0; j < depth; ++j) {
           vol_flux_y[(x_max + 2 + j) + (k)*flux_y_stride] = vol_flux_y[(x_max - j) + (k)*flux_y_stride];
@@ -705,7 +761,8 @@ void update_halo_kernel(bool use_target, int x_min, int x_max, int y_min, int y_
       // DO j=x_min-depth,x_max+depth
 
       double *mass_flux_y = field.mass_flux_y.data;
-#pragma acc parallel loop gang worker vector default(present) clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector clover_use_target(use_target) \
+  present(mass_flux_y[ : field.mass_flux_y.N()])
       for (int j = (x_min - depth + 1); j < (x_max + depth + 2); j++) {
         for (int k = 0; k < depth; ++k) {
           mass_flux_y[j + (1 - k) * flux_y_stride] = -mass_flux_y[j + (1 + 2 + k) * flux_y_stride];
@@ -716,7 +773,8 @@ void update_halo_kernel(bool use_target, int x_min, int x_max, int y_min, int y_
       // DO j=x_min-depth,x_max+depth
 
       double *mass_flux_y = field.mass_flux_y.data;
-#pragma acc parallel loop gang worker vector default(present) clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector clover_use_target(use_target) \
+  present(mass_flux_y[ : field.mass_flux_y.N()])
       for (int j = (x_min - depth + 1); j < (x_max + depth + 2); j++) {
         for (int k = 0; k < depth; ++k) {
           mass_flux_y[j + (y_max + k + 1 + 2) * flux_y_stride] = -mass_flux_y[j + (y_max + 1 - k) * flux_y_stride];
@@ -727,7 +785,8 @@ void update_halo_kernel(bool use_target, int x_min, int x_max, int y_min, int y_
       // DO k=y_min-depth,y_max+1+depth
 
       double *mass_flux_y = field.mass_flux_y.data;
-#pragma acc parallel loop gang worker vector default(present) clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector clover_use_target(use_target) \
+  present(mass_flux_y[ : field.mass_flux_y.N()])
       for (int k = (y_min - depth + 1); k < (y_max + 1 + depth + 2); k++) {
         for (int j = 0; j < depth; ++j) {
           mass_flux_y[(1 - j) + (k)*flux_y_stride] = mass_flux_y[(1 + 2 + j) + (k)*flux_y_stride];
@@ -738,7 +797,8 @@ void update_halo_kernel(bool use_target, int x_min, int x_max, int y_min, int y_
       // DO k=y_min-depth,y_max+1+depth
 
       double *mass_flux_y = field.mass_flux_y.data;
-#pragma acc parallel loop gang worker vector default(present) clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector clover_use_target(use_target) \
+  present(mass_flux_y[ : field.mass_flux_y.N()])
       for (int k = (y_min - depth + 1); k < (y_max + 1 + depth + 2); k++) {
         for (int j = 0; j < depth; ++j) {
           mass_flux_y[(x_max + 2 + j) + (k)*flux_y_stride] = mass_flux_y[(x_max - j) + (k)*flux_y_stride];

--- a/src/acc/update_tile_halo_kernel.cpp
+++ b/src/acc/update_tile_halo_kernel.cpp
@@ -1,0 +1,1060 @@
+/*
+ Crown Copyright 2012 AWE.
+
+ This file is part of CloverLeaf.
+
+ CloverLeaf is free software: you can redistribute it and/or modify it under
+ the terms of the GNU General Public License as published by the
+ Free Software Foundation, either version 3 of the License, or (at your option)
+ any later version.
+
+ CloverLeaf is distributed in the hope that it will be useful, but
+ WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ details.
+
+ You should have received a copy of the GNU General Public License along with
+ CloverLeaf. If not, see http://www.gnu.org/licenses/.
+ */
+
+#include "update_tile_halo_kernel.h"
+
+//   @brief Fortran kernel to update the external halo cells in a chunk.
+//   @author Wayne Gaudin
+//   @details Updates halo cells for the required fields at the required depth
+//   for any halo cells that lie on an external boundary. The location and type
+//   of data governs how this is carried out. External boundaries are always
+//   reflective.
+
+void update_tile_halo_l_kernel(global_variables &globals, int x_min, int x_max, int y_min, int y_max,
+                               clover::Buffer2D<double> &density0_buffer, clover::Buffer2D<double> &energy0_buffer,
+                               clover::Buffer2D<double> &pressure_buffer, clover::Buffer2D<double> &viscosity_buffer,
+                               clover::Buffer2D<double> &soundspeed_buffer, clover::Buffer2D<double> &density1_buffer,
+                               clover::Buffer2D<double> &energy1_buffer, clover::Buffer2D<double> &xvel0_buffer,
+                               clover::Buffer2D<double> &yvel0_buffer, clover::Buffer2D<double> &xvel1_buffer,
+                               clover::Buffer2D<double> &yvel1_buffer, clover::Buffer2D<double> &vol_flux_x_buffer,
+                               clover::Buffer2D<double> &vol_flux_y_buffer, clover::Buffer2D<double> &mass_flux_x_buffer,
+                               clover::Buffer2D<double> &mass_flux_y_buffer, int left_xmin, int left_xmax, int left_ymin, int left_ymax,
+                               clover::Buffer2D<double> &left_density0_buffer, clover::Buffer2D<double> &left_energy0_buffer,
+                               clover::Buffer2D<double> &left_pressure_buffer, clover::Buffer2D<double> &left_viscosity_buffer,
+                               clover::Buffer2D<double> &left_soundspeed_buffer, clover::Buffer2D<double> &left_density1_buffer,
+                               clover::Buffer2D<double> &left_energy1_buffer, clover::Buffer2D<double> &left_xvel0_buffer,
+                               clover::Buffer2D<double> &left_yvel0_buffer, clover::Buffer2D<double> &left_xvel1_buffer,
+                               clover::Buffer2D<double> &left_yvel1_buffer, clover::Buffer2D<double> &left_vol_flux_x_buffer,
+                               clover::Buffer2D<double> &left_vol_flux_y_buffer, clover::Buffer2D<double> &left_mass_flux_x_buffer,
+                               clover::Buffer2D<double> &left_mass_flux_y_buffer, const int fields[NUM_FIELDS], int depth) {
+  // Density 0
+  if (fields[field_density0] == 1) {
+    // DO k=y_min-depth,y_max+depth
+
+    double *density0 = density0_buffer.data;
+    size_t density0_sizex = density0_buffer.nX();
+    double *left_density0 = left_density0_buffer.data;
+    size_t left_density0_sizex = left_density0_buffer.nX();
+#pragma omp target teams distribute parallel for simd clover_use_target(globals.context.use_target)
+    for (int k = (y_min - depth + 1); k < (y_max + depth + 2); k++) {
+      for (int j = 0; j < depth; ++j) {
+        density0[(x_min - j) + (k)*density0_sizex] = left_density0[(left_xmax + 1 - j) + (k)*left_density0_sizex];
+      }
+    }
+  }
+
+  // Density 1
+  if (fields[field_density1] == 1) {
+    // DO k=y_min-depth,y_max+depth
+
+    double *density1 = density1_buffer.data;
+    size_t density1_sizex = density1_buffer.nX();
+    double *left_density1 = left_density1_buffer.data;
+    size_t left_density1_sizex = left_density1_buffer.nX();
+#pragma omp target teams distribute parallel for simd clover_use_target(globals.context.use_target)
+    for (int k = (y_min - depth + 1); k < (y_max + depth + 2); k++) {
+      for (int j = 0; j < depth; ++j) {
+        density1[(x_min - j) + (k)*density1_sizex] = left_density1[(left_xmax + 1 - j) + (k)*left_density1_sizex];
+      }
+    }
+  }
+
+  // Energy 0
+  if (fields[field_energy0] == 1) {
+    // DO k=y_min-depth,y_max+depth
+
+    double *energy0 = energy0_buffer.data;
+    size_t energy0_sizex = energy0_buffer.nX();
+    double *left_energy0 = left_energy0_buffer.data;
+    size_t left_energy0_sizex = left_energy0_buffer.nX();
+#pragma omp target teams distribute parallel for simd clover_use_target(globals.context.use_target)
+    for (int k = (y_min - depth + 1); k < (y_max + depth + 2); k++) {
+      for (int j = 0; j < depth; ++j) {
+        energy0[(x_min - j) + (k)*energy0_sizex] = left_energy0[(left_xmax + 1 - j) + (k)*left_energy0_sizex];
+      }
+    }
+  }
+
+  // Energy 1
+  if (fields[field_energy1] == 1) {
+    // DO k=y_min-depth,y_max+depth
+
+    double *energy1 = energy1_buffer.data;
+    size_t energy1_sizex = energy1_buffer.nX();
+    double *left_energy1 = left_energy1_buffer.data;
+    size_t left_energy1_sizex = left_energy1_buffer.nX();
+#pragma omp target teams distribute parallel for simd clover_use_target(globals.context.use_target)
+    for (int k = (y_min - depth + 1); k < (y_max + depth + 2); k++) {
+      for (int j = 0; j < depth; ++j) {
+        energy1[(x_min - j) + (k)*energy1_sizex] = left_energy1[(left_xmax + 1 - j) + (k)*left_energy1_sizex];
+      }
+    }
+  }
+
+  // Pressure
+  if (fields[field_pressure] == 1) {
+    // DO k=y_min-depth,y_max+depth
+
+    double *pressure = pressure_buffer.data;
+    size_t pressure_sizex = pressure_buffer.nX();
+    double *left_pressure = left_pressure_buffer.data;
+    size_t left_pressure_sizex = left_pressure_buffer.nX();
+#pragma omp target teams distribute parallel for simd clover_use_target(globals.context.use_target)
+    for (int k = (y_min - depth + 1); k < (y_max + depth + 2); k++) {
+      for (int j = 0; j < depth; ++j) {
+        pressure[(x_min - j) + (k)*pressure_sizex] = left_pressure[(left_xmax + 1 - j) + (k)*left_pressure_sizex];
+      }
+    }
+  }
+
+  // Viscosity
+  if (fields[field_viscosity] == 1) {
+    // DO k=y_min-depth,y_max+depth
+
+    double *viscosity = viscosity_buffer.data;
+    size_t viscosity_sizex = viscosity_buffer.nX();
+    double *left_viscosity = left_viscosity_buffer.data;
+    size_t left_viscosity_sizex = left_viscosity_buffer.nX();
+#pragma omp target teams distribute parallel for simd clover_use_target(globals.context.use_target)
+    for (int k = (y_min - depth + 1); k < (y_max + depth + 2); k++) {
+      for (int j = 0; j < depth; ++j) {
+        viscosity[(x_min - j) + (k)*viscosity_sizex] = left_viscosity[(left_xmax + 1 - j) + (k)*left_viscosity_sizex];
+      }
+    }
+  }
+
+  // Soundspeed
+  if (fields[field_soundspeed] == 1) {
+    // DO k=y_min-depth,y_max+depth
+
+    double *soundspeed = soundspeed_buffer.data;
+    size_t soundspeed_sizex = soundspeed_buffer.nX();
+    double *left_soundspeed = left_soundspeed_buffer.data;
+    size_t left_soundspeed_sizex = left_soundspeed_buffer.nX();
+#pragma omp target teams distribute parallel for simd clover_use_target(globals.context.use_target)
+    for (int k = (y_min - depth + 1); k < (y_max + depth + 2); k++) {
+      for (int j = 0; j < depth; ++j) {
+        soundspeed[(x_min - j) + (k)*soundspeed_sizex] = left_soundspeed[(left_xmax + 1 - j) + (k)*left_soundspeed_sizex];
+      }
+    }
+  }
+
+  // XVEL 0
+  if (fields[field_xvel0] == 1) {
+    // DO k=y_min-depth,y_max+1+depth
+
+    double *xvel0 = xvel0_buffer.data;
+    size_t xvel0_sizex = xvel0_buffer.nX();
+    double *left_xvel0 = left_xvel0_buffer.data;
+    size_t left_xvel0_sizex = left_xvel0_buffer.nX();
+#pragma omp target teams distribute parallel for simd clover_use_target(globals.context.use_target)
+    for (int k = (y_min - depth + 1); k < (y_max + 1 + depth + 2); k++) {
+      for (int j = 0; j < depth; ++j) {
+        xvel0[(x_min - j) + (k)*xvel0_sizex] = left_xvel0[(left_xmax + 1 - j) + (k)*left_xvel0_sizex];
+      }
+    }
+  }
+
+  // XVEL 1
+  if (fields[field_xvel1] == 1) {
+    // DO k=y_min-depth,y_max+1+depth
+
+    double *xvel1 = xvel1_buffer.data;
+    size_t xvel1_sizex = xvel1_buffer.nX();
+    double *left_xvel1 = left_xvel1_buffer.data;
+    size_t left_xvel1_sizex = left_xvel1_buffer.nX();
+#pragma omp target teams distribute parallel for simd clover_use_target(globals.context.use_target)
+    for (int k = (y_min - depth + 1); k < (y_max + 1 + depth + 2); k++) {
+      for (int j = 0; j < depth; ++j) {
+        xvel1[(x_min - j) + (k)*xvel1_sizex] = left_xvel1[(left_xmax + 1 - j) + (k)*left_xvel1_sizex];
+      }
+    }
+  }
+
+  // YVEL 0
+  if (fields[field_yvel0] == 1) {
+    // DO k=y_min-depth,y_max+1+depth
+
+    double *yvel0 = yvel0_buffer.data;
+    size_t yvel0_sizex = yvel0_buffer.nX();
+    double *left_yvel0 = left_yvel0_buffer.data;
+    size_t left_yvel0_sizex = left_yvel0_buffer.nX();
+#pragma omp target teams distribute parallel for simd clover_use_target(globals.context.use_target)
+    for (int k = (y_min - depth + 1); k < (y_max + 1 + depth + 2); k++) {
+      for (int j = 0; j < depth; ++j) {
+        yvel0[(x_min - j) + (k)*yvel0_sizex] = left_yvel0[(left_xmax + 1 - j) + (k)*left_yvel0_sizex];
+      }
+    }
+  }
+
+  // YVEL 1
+  if (fields[field_yvel1] == 1) {
+    // DO k=y_min-depth,y_max+1+depth
+
+    double *yvel1 = yvel1_buffer.data;
+    size_t yvel1_sizex = yvel1_buffer.nX();
+    double *left_yvel1 = left_yvel1_buffer.data;
+    size_t left_yvel1_sizex = left_yvel1_buffer.nX();
+#pragma omp target teams distribute parallel for simd clover_use_target(globals.context.use_target)
+    for (int k = (y_min - depth + 1); k < (y_max + 1 + depth + 2); k++) {
+      for (int j = 0; j < depth; ++j) {
+        yvel1[(x_min - j) + (k)*yvel1_sizex] = left_yvel1[(left_xmax + 1 - j) + (k)*left_yvel1_sizex];
+      }
+    }
+  }
+
+  // VOL_FLUX_X
+  if (fields[field_vol_flux_x] == 1) {
+    // DO k=y_min-depth,y_max+depth
+
+    double *vol_flux_x = vol_flux_x_buffer.data;
+    size_t vol_flux_x_sizex = vol_flux_x_buffer.nX();
+    double *left_vol_flux_x = left_vol_flux_x_buffer.data;
+    size_t left_vol_flux_x_sizex = left_vol_flux_x_buffer.nX();
+#pragma omp target teams distribute parallel for simd clover_use_target(globals.context.use_target)
+    for (int k = (y_min - depth + 1); k < (y_max + depth + 2); k++) {
+      for (int j = 0; j < depth; ++j) {
+        vol_flux_x[(x_min - j) + (k)*vol_flux_x_sizex] = left_vol_flux_x[(left_xmax + 1 - j) + (k)*left_vol_flux_x_sizex];
+      }
+    }
+  }
+
+  // MASS_FLUX_X
+  if (fields[field_mass_flux_x] == 1) {
+    // DO k=y_min-depth,y_max+depth
+
+    double *mass_flux_x = mass_flux_x_buffer.data;
+    size_t mass_flux_x_sizex = mass_flux_x_buffer.nX();
+    double *left_mass_flux_x = left_mass_flux_x_buffer.data;
+    size_t left_mass_flux_x_sizex = left_mass_flux_x_buffer.nX();
+#pragma omp target teams distribute parallel for simd clover_use_target(globals.context.use_target)
+    for (int k = (y_min - depth + 1); k < (y_max + depth + 2); k++) {
+      for (int j = 0; j < depth; ++j) {
+        mass_flux_x[(x_min - j) + (k)*mass_flux_x_sizex] = left_mass_flux_x[(left_xmax + 1 - j) + (k)*left_mass_flux_x_sizex];
+      }
+    }
+  }
+
+  // VOL_FLUX_Y
+  if (fields[field_vol_flux_y] == 1) {
+    // DO k=y_min-depth,y_max+1+depth
+
+    double *vol_flux_y = vol_flux_y_buffer.data;
+    size_t vol_flux_y_sizex = vol_flux_y_buffer.nX();
+    double *left_vol_flux_y = left_vol_flux_y_buffer.data;
+    size_t left_vol_flux_y_sizex = left_vol_flux_y_buffer.nX();
+#pragma omp target teams distribute parallel for simd clover_use_target(globals.context.use_target)
+    for (int k = (y_min - depth + 1); k < (y_max + 1 + depth + 2); k++) {
+      for (int j = 0; j < depth; ++j) {
+        vol_flux_y[(x_min - j) + (k)*vol_flux_y_sizex] = left_vol_flux_y[(left_xmax + 1 - j) + (k)*left_vol_flux_y_sizex];
+      }
+    }
+  }
+
+  // MASS_FLUX_Y
+  if (fields[field_mass_flux_y] == 1) {
+    // DO k=y_min-depth,y_max+1+depth
+
+    double *mass_flux_y = mass_flux_y_buffer.data;
+    size_t mass_flux_y_sizex = mass_flux_y_buffer.nX();
+    double *left_mass_flux_y = left_mass_flux_y_buffer.data;
+    size_t left_mass_flux_y_sizex = left_mass_flux_y_buffer.nX();
+#pragma omp target teams distribute parallel for simd clover_use_target(globals.context.use_target)
+    for (int k = (y_min - depth + 1); k < (y_max + 1 + depth + 2); k++) {
+      for (int j = 0; j < depth; ++j) {
+        mass_flux_y[(x_min - j) + (k)*mass_flux_y_sizex] = left_mass_flux_y[(left_xmax + 1 - j) + (k)*left_mass_flux_y_sizex];
+      }
+    }
+  }
+}
+
+void update_tile_halo_r_kernel(global_variables &globals, int x_min, int x_max, int y_min, int y_max,
+                               clover::Buffer2D<double> &density0_buffer, clover::Buffer2D<double> &energy0_buffer,
+                               clover::Buffer2D<double> &pressure_buffer, clover::Buffer2D<double> &viscosity_buffer,
+                               clover::Buffer2D<double> &soundspeed_buffer, clover::Buffer2D<double> &density1_buffer,
+                               clover::Buffer2D<double> &energy1_buffer, clover::Buffer2D<double> &xvel0_buffer,
+                               clover::Buffer2D<double> &yvel0_buffer, clover::Buffer2D<double> &xvel1_buffer,
+                               clover::Buffer2D<double> &yvel1_buffer, clover::Buffer2D<double> &vol_flux_x_buffer,
+                               clover::Buffer2D<double> &vol_flux_y_buffer, clover::Buffer2D<double> &mass_flux_x_buffer,
+                               clover::Buffer2D<double> &mass_flux_y_buffer, int right_xmin, int right_xmax, int right_ymin, int right_ymax,
+                               clover::Buffer2D<double> &right_density0_buffer, clover::Buffer2D<double> &right_energy0_buffer,
+                               clover::Buffer2D<double> &right_pressure_buffer, clover::Buffer2D<double> &right_viscosity_buffer,
+                               clover::Buffer2D<double> &right_soundspeed_buffer, clover::Buffer2D<double> &right_density1_buffer,
+                               clover::Buffer2D<double> &right_energy1_buffer, clover::Buffer2D<double> &right_xvel0_buffer,
+                               clover::Buffer2D<double> &right_yvel0_buffer, clover::Buffer2D<double> &right_xvel1_buffer,
+                               clover::Buffer2D<double> &right_yvel1_buffer, clover::Buffer2D<double> &right_vol_flux_x_buffer,
+                               clover::Buffer2D<double> &right_vol_flux_y_buffer, clover::Buffer2D<double> &right_mass_flux_x_buffer,
+                               clover::Buffer2D<double> &right_mass_flux_y_buffer, const int fields[NUM_FIELDS], int depth) {
+  // Density 0
+  if (fields[field_density0] == 1) {
+    // DO k=y_min-depth,y_max+depth
+
+    double *density0 = density0_buffer.data;
+    size_t density0_sizex = density0_buffer.nX();
+    double *right_density0 = right_density0_buffer.data;
+    size_t right_density0_sizex = right_density0_buffer.nX();
+#pragma omp target teams distribute parallel for simd clover_use_target(globals.context.use_target)
+    for (int k = (y_min - depth + 1); k < (y_max + depth + 2); k++) {
+      for (int j = 0; j < depth; ++j) {
+        density0[(x_max + 2 + j) + (k)*density0_sizex] = right_density0[(right_xmin - 1 + 2 + j) + (k)*right_density0_sizex];
+      }
+    }
+  }
+
+  // Density 1
+  if (fields[field_density1] == 1) {
+    // DO k=y_min-depth,y_max+depth
+
+    double *density1 = density1_buffer.data;
+    size_t density1_sizex = density1_buffer.nX();
+    double *right_density1 = right_density1_buffer.data;
+    size_t right_density1_sizex = right_density1_buffer.nX();
+#pragma omp target teams distribute parallel for simd clover_use_target(globals.context.use_target)
+    for (int k = (y_min - depth + 1); k < (y_max + depth + 2); k++) {
+      for (int j = 0; j < depth; ++j) {
+        density1[(x_max + 2 + j) + (k)*density1_sizex] = right_density1[(right_xmin - 1 + 2 + j) + (k)*right_density1_sizex];
+      }
+    }
+  }
+
+  // Energy 0
+  if (fields[field_energy0] == 1) {
+    // DO k=y_min-depth,y_max+depth
+
+    double *energy0 = energy0_buffer.data;
+    size_t energy0_sizex = energy0_buffer.nX();
+    double *right_energy0 = right_energy0_buffer.data;
+    size_t right_energy0_sizex = right_energy0_buffer.nX();
+#pragma omp target teams distribute parallel for simd clover_use_target(globals.context.use_target)
+    for (int k = (y_min - depth + 1); k < (y_max + depth + 2); k++) {
+      for (int j = 0; j < depth; ++j) {
+        energy0[(x_max + 2 + j) + (k)*energy0_sizex] = right_energy0[(right_xmin - 1 + 2 + j) + (k)*right_energy0_sizex];
+      }
+    }
+  }
+
+  // Energy 1
+  if (fields[field_energy1] == 1) {
+    // DO k=y_min-depth,y_max+depth
+
+    double *energy1 = energy1_buffer.data;
+    size_t energy1_sizex = energy1_buffer.nX();
+    double *right_energy1 = right_energy1_buffer.data;
+    size_t right_energy1_sizex = right_energy1_buffer.nX();
+#pragma omp target teams distribute parallel for simd clover_use_target(globals.context.use_target)
+    for (int k = (y_min - depth + 1); k < (y_max + depth + 2); k++) {
+      for (int j = 0; j < depth; ++j) {
+        energy1[(x_max + 2 + j) + (k)*energy1_sizex] = right_energy1[(right_xmin - 1 + 2 + j) + (k)*right_energy1_sizex];
+      }
+    }
+  }
+
+  // Pressure
+  if (fields[field_pressure] == 1) {
+    // DO k=y_min-depth,y_max+depth
+
+    double *pressure = pressure_buffer.data;
+    size_t pressure_sizex = pressure_buffer.nX();
+    double *right_pressure = right_pressure_buffer.data;
+    size_t right_pressure_sizex = right_pressure_buffer.nX();
+#pragma omp target teams distribute parallel for simd clover_use_target(globals.context.use_target)
+    for (int k = (y_min - depth + 1); k < (y_max + depth + 2); k++) {
+      for (int j = 0; j < depth; ++j) {
+        pressure[(x_max + 2 + j) + (k)*pressure_sizex] = right_pressure[(right_xmin - 1 + 2 + j) + (k)*right_pressure_sizex];
+      }
+    }
+  }
+
+  // Viscosity
+  if (fields[field_viscosity] == 1) {
+    // DO k=y_min-depth,y_max+depth
+
+    double *viscosity = viscosity_buffer.data;
+    size_t viscosity_sizex = viscosity_buffer.nX();
+    double *right_viscosity = right_viscosity_buffer.data;
+    size_t right_viscosity_sizex = right_viscosity_buffer.nX();
+#pragma omp target teams distribute parallel for simd clover_use_target(globals.context.use_target)
+    for (int k = (y_min - depth + 1); k < (y_max + depth + 2); k++) {
+      for (int j = 0; j < depth; ++j) {
+        viscosity[(x_max + 2 + j) + (k)*viscosity_sizex] = right_viscosity[(right_xmin - 1 + 2 + j) + (k)*right_viscosity_sizex];
+      }
+    }
+  }
+
+  // Soundspeed
+  if (fields[field_soundspeed] == 1) {
+    // DO k=y_min-depth,y_max+depth
+
+    double *soundspeed = soundspeed_buffer.data;
+    size_t soundspeed_sizex = soundspeed_buffer.nX();
+    double *right_soundspeed = right_soundspeed_buffer.data;
+    size_t right_soundspeed_sizex = right_soundspeed_buffer.nX();
+#pragma omp target teams distribute parallel for simd clover_use_target(globals.context.use_target)
+    for (int k = (y_min - depth + 1); k < (y_max + depth + 2); k++) {
+      for (int j = 0; j < depth; ++j) {
+        soundspeed[(x_max + 2 + j) + (k)*soundspeed_sizex] = right_soundspeed[(right_xmin - 1 + 2 + j) + (k)*right_soundspeed_sizex];
+      }
+    }
+  }
+
+  // XVEL 0
+  if (fields[field_xvel0] == 1) {
+    // DO k=y_min-depth,y_max+1+depth
+
+    double *xvel0 = xvel0_buffer.data;
+    size_t xvel0_sizex = xvel0_buffer.nX();
+    double *right_xvel0 = right_xvel0_buffer.data;
+    size_t right_xvel0_sizex = right_xvel0_buffer.nX();
+#pragma omp target teams distribute parallel for simd clover_use_target(globals.context.use_target)
+    for (int k = (y_min - depth + 1); k < (y_max + 1 + depth + 2); k++) {
+      for (int j = 0; j < depth; ++j) {
+        xvel0[(x_max + 1 + 2 + j) + (k)*xvel0_sizex] = right_xvel0[(right_xmin + 1 - 1 + 2 + j) + (k)*right_xvel0_sizex];
+      }
+    }
+  }
+
+  // XVEL 1
+  if (fields[field_xvel1] == 1) {
+    // DO k=y_min-depth,y_max+1+depth
+
+    double *xvel1 = xvel1_buffer.data;
+    size_t xvel1_sizex = xvel1_buffer.nX();
+    double *right_xvel1 = right_xvel1_buffer.data;
+    size_t right_xvel1_sizex = right_xvel1_buffer.nX();
+#pragma omp target teams distribute parallel for simd clover_use_target(globals.context.use_target)
+    for (int k = (y_min - depth + 1); k < (y_max + 1 + depth + 2); k++) {
+      for (int j = 0; j < depth; ++j) {
+        xvel1[(x_max + 1 + 2 + j) + (k)*xvel1_sizex] = right_xvel1[(right_xmin + 1 - 1 + 2 + j) + (k)*right_xvel1_sizex];
+      }
+    }
+  }
+
+  // YVEL 0
+  if (fields[field_yvel0] == 1) {
+    // DO k=y_min-depth,y_max+1+depth
+
+    double *yvel0 = yvel0_buffer.data;
+    size_t yvel0_sizex = yvel0_buffer.nX();
+    double *right_yvel0 = right_yvel0_buffer.data;
+    size_t right_yvel0_sizex = right_yvel0_buffer.nX();
+#pragma omp target teams distribute parallel for simd clover_use_target(globals.context.use_target)
+    for (int k = (y_min - depth + 1); k < (y_max + 1 + depth + 2); k++) {
+      for (int j = 0; j < depth; ++j) {
+        yvel0[(x_max + 1 + 2 + j) + (k)*yvel0_sizex] = right_yvel0[(right_xmin + 1 - 1 + 2 + j) + (k)*right_yvel0_sizex];
+      }
+    }
+  }
+
+  // YVEL 1
+  if (fields[field_yvel1] == 1) {
+    // DO k=y_min-depth,y_max+1+depth
+
+    double *yvel1 = yvel1_buffer.data;
+    size_t yvel1_sizex = yvel1_buffer.nX();
+    double *right_yvel1 = right_yvel1_buffer.data;
+    size_t right_yvel1_sizex = right_yvel1_buffer.nX();
+#pragma omp target teams distribute parallel for simd clover_use_target(globals.context.use_target)
+    for (int k = (y_min - depth + 1); k < (y_max + 1 + depth + 2); k++) {
+      for (int j = 0; j < depth; ++j) {
+        yvel1[(x_max + 1 + 2 + j) + (k)*yvel1_sizex] = right_yvel1[(right_xmin + 1 - 1 + 2 + j) + (k)*right_yvel1_sizex];
+      }
+    }
+  }
+
+  // VOL_FLUX_X
+  if (fields[field_vol_flux_x] == 1) {
+    // DO k=y_min-depth,y_max+depth
+
+    double *vol_flux_x = vol_flux_x_buffer.data;
+    size_t vol_flux_x_sizex = vol_flux_x_buffer.nX();
+    double *right_vol_flux_x = right_vol_flux_x_buffer.data;
+    size_t right_vol_flux_x_sizex = right_vol_flux_x_buffer.nX();
+#pragma omp target teams distribute parallel for simd clover_use_target(globals.context.use_target)
+    for (int k = (y_min - depth + 1); k < (y_max + depth + 2); k++) {
+      for (int j = 0; j < depth; ++j) {
+        vol_flux_x[(x_max + 1 + 2 + j) + (k)*vol_flux_x_sizex] =
+            right_vol_flux_x[(right_xmin + 1 - 1 + 2 + j) + (k)*right_vol_flux_x_sizex];
+      }
+    }
+  }
+
+  // MASS_FLUX_X
+  if (fields[field_mass_flux_x] == 1) {
+    // DO k=y_min-depth,y_max+depth
+
+    double *mass_flux_x = mass_flux_x_buffer.data;
+    size_t mass_flux_x_sizex = mass_flux_x_buffer.nX();
+    double *right_mass_flux_x = right_mass_flux_x_buffer.data;
+    size_t right_mass_flux_x_sizex = right_mass_flux_x_buffer.nX();
+#pragma omp target teams distribute parallel for simd clover_use_target(globals.context.use_target)
+    for (int k = (y_min - depth + 1); k < (y_max + depth + 2); k++) {
+      for (int j = 0; j < depth; ++j) {
+        mass_flux_x[(x_max + 1 + 2 + j) + (k)*mass_flux_x_sizex] =
+            right_mass_flux_x[(right_xmin + 1 - 1 + 2 + j) + (k)*right_mass_flux_x_sizex];
+      }
+    }
+  }
+
+  // VOL_FLUX_Y
+  if (fields[field_vol_flux_y] == 1) {
+    // DO k=y_min-depth,y_max+1+depth
+
+    double *vol_flux_y = vol_flux_y_buffer.data;
+    size_t vol_flux_y_sizex = vol_flux_y_buffer.nX();
+    double *right_vol_flux_y = right_vol_flux_y_buffer.data;
+    size_t right_vol_flux_y_sizex = right_vol_flux_y_buffer.nX();
+#pragma omp target teams distribute parallel for simd clover_use_target(globals.context.use_target)
+    for (int k = (y_min - depth + 1); k < (y_max + 1 + depth + 2); k++) {
+      for (int j = 0; j < depth; ++j) {
+        vol_flux_y[(x_max + 2 + j) + (k)*vol_flux_y_sizex] = right_vol_flux_y[(right_xmin - 1 + 2 + j) + (k)*right_vol_flux_y_sizex];
+      }
+    }
+  }
+
+  // MASS_FLUX_Y
+  if (fields[field_mass_flux_y] == 1) {
+    // DO k=y_min-depth,y_max+1+depth
+
+    double *mass_flux_y = mass_flux_y_buffer.data;
+    size_t mass_flux_y_sizex = mass_flux_y_buffer.nX();
+    double *right_mass_flux_y = right_mass_flux_y_buffer.data;
+    size_t right_mass_flux_y_sizex = right_mass_flux_y_buffer.nX();
+#pragma omp target teams distribute parallel for simd clover_use_target(globals.context.use_target)
+    for (int k = (y_min - depth + 1); k < (y_max + 1 + depth + 2); k++) {
+      for (int j = 0; j < depth; ++j) {
+        mass_flux_y[(x_max + 2 + j) + (k)*mass_flux_y_sizex] = right_mass_flux_y[(right_xmin - 1 + 2 + j) + (k)*right_mass_flux_y_sizex];
+      }
+    }
+  }
+}
+
+//  Top and bottom only do xmin -> xmax
+//  This is because the corner ghosts will get communicated in the left right
+//  communication
+
+void update_tile_halo_t_kernel(
+    global_variables &globals, int x_min, int x_max, int y_min, int y_max, clover::Buffer2D<double> &density0_buffer,
+    clover::Buffer2D<double> &energy0_buffer, clover::Buffer2D<double> &pressure_buffer, clover::Buffer2D<double> &viscosity_buffer,
+    clover::Buffer2D<double> &soundspeed_buffer, clover::Buffer2D<double> &density1_buffer, clover::Buffer2D<double> &energy1_buffer,
+    clover::Buffer2D<double> &xvel0_buffer, clover::Buffer2D<double> &yvel0_buffer, clover::Buffer2D<double> &xvel1_buffer,
+    clover::Buffer2D<double> &yvel1_buffer, clover::Buffer2D<double> &vol_flux_x_buffer, clover::Buffer2D<double> &vol_flux_y_buffer,
+    clover::Buffer2D<double> &mass_flux_x_buffer, clover::Buffer2D<double> &mass_flux_y_buffer, int top_xmin, int top_xmax, int top_ymin,
+    int top_ymax, clover::Buffer2D<double> &top_density0_buffer, clover::Buffer2D<double> &top_energy0_buffer,
+    clover::Buffer2D<double> &top_pressure_buffer, clover::Buffer2D<double> &top_viscosity_buffer,
+    clover::Buffer2D<double> &top_soundspeed_buffer, clover::Buffer2D<double> &top_density1_buffer,
+    clover::Buffer2D<double> &top_energy1_buffer, clover::Buffer2D<double> &top_xvel0_buffer, clover::Buffer2D<double> &top_yvel0_buffer,
+    clover::Buffer2D<double> &top_xvel1_buffer, clover::Buffer2D<double> &top_yvel1_buffer, clover::Buffer2D<double> &top_vol_flux_x_buffer,
+    clover::Buffer2D<double> &top_vol_flux_y_buffer, clover::Buffer2D<double> &top_mass_flux_x_buffer,
+    clover::Buffer2D<double> &top_mass_flux_y_buffer, const int fields[NUM_FIELDS], int depth) {
+  // Density 0
+  if (fields[field_density0] == 1) {
+    for (int k = 0; k < depth; ++k) {
+      // DO j=x_min-depth, x_max+depth
+
+      double *density0 = density0_buffer.data;
+      size_t density0_sizex = density0_buffer.nX();
+      double *top_density0 = top_density0_buffer.data;
+      size_t top_density0_sizex = top_density0_buffer.nX();
+#pragma omp target teams distribute parallel for simd clover_use_target(globals.context.use_target)
+      for (int j = (x_min - depth + 1); j < (x_max + depth + 2); j++) {
+        density0[j + (y_max + 2 + k) * density0_sizex] = top_density0[j + (top_ymin - 1 + 2 + k) * top_density0_sizex];
+      }
+    }
+  }
+
+  // Density 1
+  if (fields[field_density1] == 1) {
+    for (int k = 0; k < depth; ++k) {
+      // DO j=x_min-depth, x_max+depth
+
+      double *density1 = density1_buffer.data;
+      size_t density1_sizex = density1_buffer.nX();
+      double *top_density1 = top_density1_buffer.data;
+      size_t top_density1_sizex = top_density1_buffer.nX();
+#pragma omp target teams distribute parallel for simd clover_use_target(globals.context.use_target)
+      for (int j = (x_min - depth + 1); j < (x_max + depth + 2); j++) {
+        density1[j + (y_max + 2 + k) * density1_sizex] = top_density1[j + (top_ymin - 1 + 2 + k) * top_density1_sizex];
+      }
+    }
+  }
+
+  // Energy 0
+  if (fields[field_energy0] == 1) {
+    for (int k = 0; k < depth; ++k) {
+      // DO j=x_min-depth, x_max+depth
+
+      double *energy0 = energy0_buffer.data;
+      size_t energy0_sizex = energy0_buffer.nX();
+      double *top_energy0 = top_energy0_buffer.data;
+      size_t top_energy0_sizex = top_energy0_buffer.nX();
+#pragma omp target teams distribute parallel for simd clover_use_target(globals.context.use_target)
+      for (int j = (x_min - depth + 1); j < (x_max + depth + 2); j++) {
+        energy0[j + (y_max + 2 + k) * energy0_sizex] = top_energy0[j + (top_ymin - 1 + 2 + k) * top_energy0_sizex];
+      }
+    }
+  }
+
+  // Energy 1
+  if (fields[field_energy1] == 1) {
+    for (int k = 0; k < depth; ++k) {
+      // DO j=x_min-depth, x_max+depth
+
+      double *energy1 = energy1_buffer.data;
+      size_t energy1_sizex = energy1_buffer.nX();
+      double *top_energy1 = top_energy1_buffer.data;
+      size_t top_energy1_sizex = top_energy1_buffer.nX();
+#pragma omp target teams distribute parallel for simd clover_use_target(globals.context.use_target)
+      for (int j = (x_min - depth + 1); j < (x_max + depth + 2); j++) {
+        energy1[j + (y_max + 2 + k) * energy1_sizex] = top_energy1[j + (top_ymin - 1 + 2 + k) * top_energy1_sizex];
+      }
+    }
+  }
+
+  // Pressure
+  if (fields[field_pressure] == 1) {
+    for (int k = 0; k < depth; ++k) {
+      // DO j=x_min-depth, x_max+depth
+
+      double *pressure = pressure_buffer.data;
+      size_t pressure_sizex = pressure_buffer.nX();
+      double *top_pressure = top_pressure_buffer.data;
+      size_t top_pressure_sizex = top_pressure_buffer.nX();
+#pragma omp target teams distribute parallel for simd clover_use_target(globals.context.use_target)
+      for (int j = (x_min - depth + 1); j < (x_max + depth + 2); j++) {
+        pressure[j + (y_max + 2 + k) * pressure_sizex] = top_pressure[j + (top_ymin - 1 + 2 + k) * top_pressure_sizex];
+      }
+    }
+  }
+
+  // Viscocity
+  if (fields[field_viscosity] == 1) {
+    for (int k = 0; k < depth; ++k) {
+      // DO j=x_min-depth, x_max+depth
+
+      double *viscosity = viscosity_buffer.data;
+      size_t viscosity_sizex = viscosity_buffer.nX();
+      double *top_viscosity = top_viscosity_buffer.data;
+      size_t top_viscosity_sizex = top_viscosity_buffer.nX();
+#pragma omp target teams distribute parallel for simd clover_use_target(globals.context.use_target)
+      for (int j = (x_min - depth + 1); j < (x_max + depth + 2); j++) {
+        viscosity[j + (y_max + 2 + k) * viscosity_sizex] = top_viscosity[j + (top_ymin - 1 + 2 + k) * top_viscosity_sizex];
+      }
+    }
+  }
+
+  // Soundspeed
+  if (fields[field_soundspeed] == 1) {
+    for (int k = 0; k < depth; ++k) {
+      // DO j=x_min-depth, x_max+depth
+
+      double *soundspeed = soundspeed_buffer.data;
+      size_t soundspeed_sizex = soundspeed_buffer.nX();
+      double *top_soundspeed = top_soundspeed_buffer.data;
+      size_t top_soundspeed_sizex = top_soundspeed_buffer.nX();
+#pragma omp target teams distribute parallel for simd clover_use_target(globals.context.use_target)
+      for (int j = (x_min - depth + 1); j < (x_max + depth + 2); j++) {
+        soundspeed[j + (y_max + 2 + k) * soundspeed_sizex] = top_soundspeed[j + (top_ymin - 1 + 2 + k) * top_soundspeed_sizex];
+      }
+    }
+  }
+
+  // XVEL 0
+  if (fields[field_xvel0] == 1) {
+    for (int k = 0; k < depth; ++k) {
+      // DO j=x_min-depth, x_max+1+depth
+
+      double *xvel0 = xvel0_buffer.data;
+      size_t xvel0_sizex = xvel0_buffer.nX();
+      double *top_xvel0 = top_xvel0_buffer.data;
+      size_t top_xvel0_sizex = top_xvel0_buffer.nX();
+#pragma omp target teams distribute parallel for simd clover_use_target(globals.context.use_target)
+      for (int j = (x_min - depth + 1); j < (x_max + 1 + depth + 2); j++) {
+        xvel0[j + (y_max + 1 + 2 + k) * xvel0_sizex] = top_xvel0[j + (top_ymin + 1 - 1 + 2 + k) * top_xvel0_sizex];
+      }
+    }
+  }
+
+  // XVEL 1
+  if (fields[field_xvel1] == 1) {
+    for (int k = 0; k < depth; ++k) {
+      // DO j=x_min-depth, x_max+1+depth
+
+      double *xvel1 = xvel1_buffer.data;
+      size_t xvel1_sizex = xvel1_buffer.nX();
+      double *top_xvel1 = top_xvel1_buffer.data;
+      size_t top_xvel1_sizex = top_xvel1_buffer.nX();
+#pragma omp target teams distribute parallel for simd clover_use_target(globals.context.use_target)
+      for (int j = (x_min - depth + 1); j < (x_max + 1 + depth + 2); j++) {
+        xvel1[j + (y_max + 1 + 2 + k) * xvel1_sizex] = top_xvel1[j + (top_ymin + 1 - 1 + 2 + k) * top_xvel1_sizex];
+      }
+    }
+  }
+
+  // YVEL 0
+  if (fields[field_yvel0] == 1) {
+    for (int k = 0; k < depth; ++k) {
+      // DO j=x_min-depth, x_max+1+depth
+
+      double *yvel0 = yvel0_buffer.data;
+      size_t yvel0_sizex = yvel0_buffer.nX();
+      double *top_yvel0 = top_yvel0_buffer.data;
+      size_t top_yvel0_sizex = top_yvel0_buffer.nX();
+#pragma omp target teams distribute parallel for simd clover_use_target(globals.context.use_target)
+      for (int j = (x_min - depth + 1); j < (x_max + 1 + depth + 2); j++) {
+        yvel0[j + (y_max + 1 + 2 + k) * yvel0_sizex] = top_yvel0[j + (top_ymin + 1 - 1 + 2 + k) * top_yvel0_sizex];
+      }
+    }
+  }
+
+  // YVEL 1
+  if (fields[field_yvel1] == 1) {
+    for (int k = 0; k < depth; ++k) {
+      // DO j=x_min-depth, x_max+1+depth
+
+      double *yvel1 = yvel1_buffer.data;
+      size_t yvel1_sizex = yvel1_buffer.nX();
+      double *top_yvel1 = top_yvel1_buffer.data;
+      size_t top_yvel1_sizex = top_yvel1_buffer.nX();
+#pragma omp target teams distribute parallel for simd clover_use_target(globals.context.use_target)
+      for (int j = (x_min - depth + 1); j < (x_max + 1 + depth + 2); j++) {
+        yvel1[j + (y_max + 1 + 2 + k) * yvel1_sizex] = top_yvel1[j + (top_ymin + 1 - 1 + 2 + k) * top_yvel1_sizex];
+      }
+    }
+  }
+
+  // VOL_FLUX_X
+  if (fields[field_vol_flux_x] == 1) {
+    for (int k = 0; k < depth; ++k) {
+      // DO j=x_min-depth, x_max+1+depth
+
+      double *vol_flux_x = vol_flux_x_buffer.data;
+      size_t vol_flux_x_sizex = vol_flux_x_buffer.nX();
+      double *top_vol_flux_x = top_vol_flux_x_buffer.data;
+      size_t top_vol_flux_x_sizex = top_vol_flux_x_buffer.nX();
+#pragma omp target teams distribute parallel for simd clover_use_target(globals.context.use_target)
+      for (int j = (x_min - depth + 1); j < (x_max + 1 + depth + 2); j++) {
+        vol_flux_x[j + (y_max + 2 + k) * vol_flux_x_sizex] = top_vol_flux_x[j + (top_ymin - 1 + 2 + k) * top_vol_flux_x_sizex];
+      }
+    }
+  }
+
+  // MASS_FLUX_X
+  if (fields[field_mass_flux_x] == 1) {
+    for (int k = 0; k < depth; ++k) {
+      // DO j=x_min-depth, x_max+1+depth
+
+      double *mass_flux_x = mass_flux_x_buffer.data;
+      size_t mass_flux_x_sizex = mass_flux_x_buffer.nX();
+      double *top_mass_flux_x = top_mass_flux_x_buffer.data;
+      size_t top_mass_flux_x_sizex = top_mass_flux_x_buffer.nX();
+#pragma omp target teams distribute parallel for simd clover_use_target(globals.context.use_target)
+      for (int j = (x_min - depth + 1); j < (x_max + 1 + depth + 2); j++) {
+        mass_flux_x[j + (y_max + 2 + k) * mass_flux_x_sizex] = top_mass_flux_x[j + (top_ymin - 1 + 2 + k) * top_mass_flux_x_sizex];
+      }
+    }
+  }
+
+  // VOL_FLUX_Y
+  if (fields[field_vol_flux_y] == 1) {
+    for (int k = 0; k < depth; ++k) {
+      // DO j=x_min-depth, x_max+depth
+
+      double *vol_flux_y = vol_flux_y_buffer.data;
+      size_t vol_flux_y_sizex = vol_flux_y_buffer.nX();
+      double *top_vol_flux_y = top_vol_flux_y_buffer.data;
+      size_t top_vol_flux_y_sizex = top_vol_flux_y_buffer.nX();
+#pragma omp target teams distribute parallel for simd clover_use_target(globals.context.use_target)
+      for (int j = (x_min - depth + 1); j < (x_max + depth + 2); j++) {
+        vol_flux_y[j + (y_max + 1 + 2 + k) * vol_flux_y_sizex] = top_vol_flux_y[j + (top_ymin + 1 - 1 + 2 + k) * top_vol_flux_y_sizex];
+      }
+    }
+  }
+
+  // MASS_FLUX_Y
+  if (fields[field_mass_flux_y] == 1) {
+    for (int k = 0; k < depth; ++k) {
+      // DO j=x_min-depth, x_max+depth
+
+      double *mass_flux_y = mass_flux_y_buffer.data;
+      size_t mass_flux_y_sizex = mass_flux_y_buffer.nX();
+      double *top_mass_flux_y = top_mass_flux_y_buffer.data;
+      size_t top_mass_flux_y_sizex = top_mass_flux_y_buffer.nX();
+#pragma omp target teams distribute parallel for simd clover_use_target(globals.context.use_target)
+      for (int j = (x_min - depth + 1); j < (x_max + depth + 2); j++) {
+        mass_flux_y[j + (y_max + 1 + 2 + k) * mass_flux_y_sizex] = top_mass_flux_y[j + (top_ymin + 1 - 1 + 2 + k) * top_mass_flux_y_sizex];
+      }
+    }
+  }
+}
+
+void update_tile_halo_b_kernel(
+    global_variables &globals, int x_min, int x_max, int y_min, int y_max, clover::Buffer2D<double> &density0_buffer,
+    clover::Buffer2D<double> &energy0_buffer, clover::Buffer2D<double> &pressure_buffer, clover::Buffer2D<double> &viscosity_buffer,
+    clover::Buffer2D<double> &soundspeed_buffer, clover::Buffer2D<double> &density1_buffer, clover::Buffer2D<double> &energy1_buffer,
+    clover::Buffer2D<double> &xvel0_buffer, clover::Buffer2D<double> &yvel0_buffer, clover::Buffer2D<double> &xvel1_buffer,
+    clover::Buffer2D<double> &yvel1_buffer, clover::Buffer2D<double> &vol_flux_x_buffer, clover::Buffer2D<double> &vol_flux_y_buffer,
+    clover::Buffer2D<double> &mass_flux_x_buffer, clover::Buffer2D<double> &mass_flux_y_buffer, int bottom_xmin, int bottom_xmax,
+    int bottom_ymin, int bottom_ymax, clover::Buffer2D<double> &bottom_density0_buffer, clover::Buffer2D<double> &bottom_energy0_buffer,
+    clover::Buffer2D<double> &bottom_pressure_buffer, clover::Buffer2D<double> &bottom_viscosity_buffer,
+    clover::Buffer2D<double> &bottom_soundspeed_buffer, clover::Buffer2D<double> &bottom_density1_buffer,
+    clover::Buffer2D<double> &bottom_energy1_buffer, clover::Buffer2D<double> &bottom_xvel0_buffer,
+    clover::Buffer2D<double> &bottom_yvel0_buffer, clover::Buffer2D<double> &bottom_xvel1_buffer,
+    clover::Buffer2D<double> &bottom_yvel1_buffer, clover::Buffer2D<double> &bottom_vol_flux_x_buffer,
+    clover::Buffer2D<double> &bottom_vol_flux_y_buffer, clover::Buffer2D<double> &bottom_mass_flux_x_buffer,
+    clover::Buffer2D<double> &bottom_mass_flux_y_buffer, const int fields[NUM_FIELDS], int depth) {
+  // Density 0
+  if (fields[field_density0] == 1) {
+    for (int k = 0; k < depth; ++k) {
+      //  DO j=x_min-depth, x_max+depth
+
+      double *density0 = density0_buffer.data;
+      size_t density0_sizex = density0_buffer.nX();
+      double *bottom_density0 = bottom_density0_buffer.data;
+      size_t bottom_density0_sizex = bottom_density0_buffer.nX();
+#pragma omp target teams distribute parallel for simd clover_use_target(globals.context.use_target)
+      for (int j = (x_min - depth + 1); j < (x_max + depth + 2); j++) {
+        density0[j + (y_min - k) * density0_sizex] = bottom_density0[j + (bottom_ymax + 1 - k) * bottom_density0_sizex];
+      }
+    }
+  }
+
+  // Density 1
+  if (fields[field_density1] == 1) {
+    for (int k = 0; k < depth; ++k) {
+      //  DO j=x_min-depth, x_max+depth
+
+      double *density1 = density1_buffer.data;
+      size_t density1_sizex = density1_buffer.nX();
+      double *bottom_density1 = bottom_density1_buffer.data;
+      size_t bottom_density1_sizex = bottom_density1_buffer.nX();
+#pragma omp target teams distribute parallel for simd clover_use_target(globals.context.use_target)
+      for (int j = (x_min - depth + 1); j < (x_max + depth + 2); j++) {
+        density1[j + (y_min - k) * density1_sizex] = bottom_density1[j + (bottom_ymax + 1 - k) * bottom_density1_sizex];
+      }
+    }
+  }
+
+  // Energy 0
+  if (fields[field_energy0] == 1) {
+    for (int k = 0; k < depth; ++k) {
+      //  DO j=x_min-depth, x_max+depth
+
+      double *energy0 = energy0_buffer.data;
+      size_t energy0_sizex = energy0_buffer.nX();
+      double *bottom_energy0 = bottom_energy0_buffer.data;
+      size_t bottom_energy0_sizex = bottom_energy0_buffer.nX();
+#pragma omp target teams distribute parallel for simd clover_use_target(globals.context.use_target)
+      for (int j = (x_min - depth + 1); j < (x_max + depth + 2); j++) {
+        energy0[j + (y_min - k) * energy0_sizex] = bottom_energy0[j + (bottom_ymax + 1 - k) * bottom_energy0_sizex];
+      }
+    }
+  }
+
+  // Energy 1
+  if (fields[field_energy1] == 1) {
+    for (int k = 0; k < depth; ++k) {
+      //  DO j=x_min-depth, x_max+depth
+
+      double *energy1 = energy1_buffer.data;
+      size_t energy1_sizex = energy1_buffer.nX();
+      double *bottom_energy1 = bottom_energy1_buffer.data;
+      size_t bottom_energy1_sizex = bottom_energy1_buffer.nX();
+#pragma omp target teams distribute parallel for simd clover_use_target(globals.context.use_target)
+      for (int j = (x_min - depth + 1); j < (x_max + depth + 2); j++) {
+        energy1[j + (y_min - k) * energy1_sizex] = bottom_energy1[j + (bottom_ymax + 1 - k) * bottom_energy1_sizex];
+      }
+    }
+  }
+
+  // Pressure
+  if (fields[field_pressure] == 1) {
+    for (int k = 0; k < depth; ++k) {
+      //  DO j=x_min-depth, x_max+depth
+
+      double *pressure = pressure_buffer.data;
+      size_t pressure_sizex = pressure_buffer.nX();
+      double *bottom_pressure = bottom_pressure_buffer.data;
+      size_t bottom_pressure_sizex = bottom_pressure_buffer.nX();
+#pragma omp target teams distribute parallel for simd clover_use_target(globals.context.use_target)
+      for (int j = (x_min - depth + 1); j < (x_max + depth + 2); j++) {
+        pressure[j + (y_min - k) * pressure_sizex] = bottom_pressure[j + (bottom_ymax + 1 - k) * bottom_pressure_sizex];
+      }
+    }
+  }
+
+  // Viscocity
+  if (fields[field_viscosity] == 1) {
+    for (int k = 0; k < depth; ++k) {
+      //  DO j=x_min-depth, x_max+depth
+
+      double *viscosity = viscosity_buffer.data;
+      size_t viscosity_sizex = viscosity_buffer.nX();
+      double *bottom_viscosity = bottom_viscosity_buffer.data;
+      size_t bottom_viscosity_sizex = bottom_viscosity_buffer.nX();
+#pragma omp target teams distribute parallel for simd clover_use_target(globals.context.use_target)
+      for (int j = (x_min - depth + 1); j < (x_max + depth + 2); j++) {
+        viscosity[j + (y_min - k) * viscosity_sizex] = bottom_viscosity[j + (bottom_ymax + 1 - k) * bottom_viscosity_sizex];
+      }
+    }
+  }
+
+  // Soundspeed
+  if (fields[field_soundspeed] == 1) {
+    for (int k = 0; k < depth; ++k) {
+      //  DO j=x_min-depth, x_max+depth
+
+      double *soundspeed = soundspeed_buffer.data;
+      size_t soundspeed_sizex = soundspeed_buffer.nX();
+      double *bottom_soundspeed = bottom_soundspeed_buffer.data;
+      size_t bottom_soundspeed_sizex = bottom_soundspeed_buffer.nX();
+#pragma omp target teams distribute parallel for simd clover_use_target(globals.context.use_target)
+      for (int j = (x_min - depth + 1); j < (x_max + depth + 2); j++) {
+        soundspeed[j + (y_min - k) * soundspeed_sizex] = bottom_soundspeed[j + (bottom_ymax + 1 - k) * bottom_soundspeed_sizex];
+      }
+    }
+  }
+
+  // XVEL 0
+  if (fields[field_xvel0] == 1) {
+    for (int k = 0; k < depth; ++k) {
+      // DO j=x_min-depth, x_max+1+depth
+
+      double *xvel0 = xvel0_buffer.data;
+      size_t xvel0_sizex = xvel0_buffer.nX();
+      double *bottom_xvel0 = bottom_xvel0_buffer.data;
+      size_t bottom_xvel0_sizex = bottom_xvel0_buffer.nX();
+#pragma omp target teams distribute parallel for simd clover_use_target(globals.context.use_target)
+      for (int j = (x_min - depth + 1); j < (x_max + 1 + depth + 2); j++) {
+        xvel0[j + (y_min - k) * xvel0_sizex] = bottom_xvel0[j + (bottom_ymax + 1 - k) * bottom_xvel0_sizex];
+      }
+    }
+  }
+
+  // XVEL 1
+  if (fields[field_xvel1] == 1) {
+    for (int k = 0; k < depth; ++k) {
+      // DO j=x_min-depth, x_max+1+depth
+
+      double *xvel1 = xvel1_buffer.data;
+      size_t xvel1_sizex = xvel1_buffer.nX();
+      double *bottom_xvel1 = bottom_xvel1_buffer.data;
+      size_t bottom_xvel1_sizex = bottom_xvel1_buffer.nX();
+#pragma omp target teams distribute parallel for simd clover_use_target(globals.context.use_target)
+      for (int j = (x_min - depth + 1); j < (x_max + 1 + depth + 2); j++) {
+        xvel1[j + (y_min - k) * xvel1_sizex] = bottom_xvel1[j + (bottom_ymax + 1 - k) * bottom_xvel1_sizex];
+      }
+    }
+  }
+
+  // YVEL 0
+  if (fields[field_yvel0] == 1) {
+    for (int k = 0; k < depth; ++k) {
+      // DO j=x_min-depth, x_max+1+depth
+
+      double *yvel0 = yvel0_buffer.data;
+      size_t yvel0_sizex = yvel0_buffer.nX();
+      double *bottom_yvel0 = bottom_yvel0_buffer.data;
+      size_t bottom_yvel0_sizex = bottom_yvel0_buffer.nX();
+#pragma omp target teams distribute parallel for simd clover_use_target(globals.context.use_target)
+      for (int j = (x_min - depth + 1); j < (x_max + 1 + depth + 2); j++) {
+        yvel0[j + (y_min - k) * yvel0_sizex] = bottom_yvel0[j + (bottom_ymax + 1 - k) * bottom_yvel0_sizex];
+      }
+    }
+  }
+
+  // YVEL 1
+  if (fields[field_yvel1] == 1) {
+    for (int k = 0; k < depth; ++k) {
+      // DO j=x_min-depth, x_max+1+depth
+
+      double *yvel1 = yvel1_buffer.data;
+      size_t yvel1_sizex = yvel1_buffer.nX();
+      double *bottom_yvel1 = bottom_yvel1_buffer.data;
+      size_t bottom_yvel1_sizex = bottom_yvel1_buffer.nX();
+#pragma omp target teams distribute parallel for simd clover_use_target(globals.context.use_target)
+      for (int j = (x_min - depth + 1); j < (x_max + 1 + depth + 2); j++) {
+        yvel1[j + (y_min - k) * yvel1_sizex] = bottom_yvel1[j + (bottom_ymax + 1 - k) * bottom_yvel1_sizex];
+      }
+    }
+  }
+
+  // VOL_FLUX_X
+  if (fields[field_vol_flux_x] == 1) {
+    for (int k = 0; k < depth; ++k) {
+      // DO j=x_min-depth, x_max+1+depth
+
+      double *vol_flux_x = vol_flux_x_buffer.data;
+      size_t vol_flux_x_sizex = vol_flux_x_buffer.nX();
+      double *bottom_vol_flux_x = bottom_vol_flux_x_buffer.data;
+      size_t bottom_vol_flux_x_sizex = bottom_vol_flux_x_buffer.nX();
+#pragma omp target teams distribute parallel for simd clover_use_target(globals.context.use_target)
+      for (int j = (x_min - depth + 1); j < (x_max + 1 + depth + 2); j++) {
+        vol_flux_x[j + (y_min - k) * vol_flux_x_sizex] = bottom_vol_flux_x[j + (bottom_ymax + 1 - k) * bottom_vol_flux_x_sizex];
+      }
+    }
+  }
+
+  // MASS_FLUX_X
+  if (fields[field_mass_flux_x] == 1) {
+    for (int k = 0; k < depth; ++k) {
+      // DO j=x_min-depth, x_max+1+depth
+
+      double *mass_flux_x = mass_flux_x_buffer.data;
+      size_t mass_flux_x_sizex = mass_flux_x_buffer.nX();
+      double *bottom_mass_flux_x = bottom_mass_flux_x_buffer.data;
+      size_t bottom_mass_flux_x_sizex = bottom_mass_flux_x_buffer.nX();
+#pragma omp target teams distribute parallel for simd clover_use_target(globals.context.use_target)
+      for (int j = (x_min - depth + 1); j < (x_max + 1 + depth + 2); j++) {
+        mass_flux_x[j + (y_min - k) * mass_flux_x_sizex] = bottom_mass_flux_x[j + (bottom_ymax + 1 - k) * bottom_mass_flux_x_sizex];
+      }
+    }
+  }
+
+  // VOL_FLUX_Y
+  if (fields[field_vol_flux_y] == 1) {
+    for (int k = 0; k < depth; ++k) {
+      // DO j=x_min-depth, x_max+depth
+
+      double *vol_flux_y = vol_flux_y_buffer.data;
+      size_t vol_flux_y_sizex = vol_flux_y_buffer.nX();
+      double *bottom_vol_flux_y = bottom_vol_flux_y_buffer.data;
+      size_t bottom_vol_flux_y_sizex = bottom_vol_flux_y_buffer.nX();
+#pragma omp target teams distribute parallel for simd clover_use_target(globals.context.use_target)
+      for (int j = (x_min - depth + 1); j < (x_max + depth + 2); j++) {
+        vol_flux_y[j + (y_min - k) * vol_flux_y_sizex] = bottom_vol_flux_y[j + (bottom_ymax + 1 - k) * bottom_vol_flux_y_sizex];
+      }
+    }
+  }
+
+  // MASS_FLUX_Y
+  if (fields[field_mass_flux_y] == 1) {
+    for (int k = 0; k < depth; ++k) {
+      // DO j=x_min-depth, x_max+depth
+
+      double *mass_flux_y = mass_flux_y_buffer.data;
+      size_t mass_flux_y_sizex = mass_flux_y_buffer.nX();
+      double *bottom_mass_flux_y = bottom_mass_flux_y_buffer.data;
+      size_t bottom_mass_flux_y_sizex = bottom_mass_flux_y_buffer.nX();
+#pragma omp target teams distribute parallel for simd clover_use_target(globals.context.use_target)
+      for (int j = (x_min - depth + 1); j < (x_max + depth + 2); j++) {
+        mass_flux_y[j + (y_min - k) * mass_flux_y_sizex] = bottom_mass_flux_y[j + (bottom_ymax + 1 - k) * bottom_mass_flux_y_sizex];
+      }
+    }
+  }
+}

--- a/src/acc/update_tile_halo_kernel.cpp
+++ b/src/acc/update_tile_halo_kernel.cpp
@@ -51,7 +51,7 @@ void update_tile_halo_l_kernel(global_variables &globals, int x_min, int x_max, 
     size_t density0_sizex = density0_buffer.nX();
     double *left_density0 = left_density0_buffer.data;
     size_t left_density0_sizex = left_density0_buffer.nX();
-#pragma omp target teams distribute parallel for simd clover_use_target(globals.context.use_target)
+#pragma acc parallel loop gang worker vector default(present) clover_use_target(globals.context.use_target)
     for (int k = (y_min - depth + 1); k < (y_max + depth + 2); k++) {
       for (int j = 0; j < depth; ++j) {
         density0[(x_min - j) + (k)*density0_sizex] = left_density0[(left_xmax + 1 - j) + (k)*left_density0_sizex];
@@ -67,7 +67,7 @@ void update_tile_halo_l_kernel(global_variables &globals, int x_min, int x_max, 
     size_t density1_sizex = density1_buffer.nX();
     double *left_density1 = left_density1_buffer.data;
     size_t left_density1_sizex = left_density1_buffer.nX();
-#pragma omp target teams distribute parallel for simd clover_use_target(globals.context.use_target)
+#pragma acc parallel loop gang worker vector default(present) clover_use_target(globals.context.use_target)
     for (int k = (y_min - depth + 1); k < (y_max + depth + 2); k++) {
       for (int j = 0; j < depth; ++j) {
         density1[(x_min - j) + (k)*density1_sizex] = left_density1[(left_xmax + 1 - j) + (k)*left_density1_sizex];
@@ -83,7 +83,7 @@ void update_tile_halo_l_kernel(global_variables &globals, int x_min, int x_max, 
     size_t energy0_sizex = energy0_buffer.nX();
     double *left_energy0 = left_energy0_buffer.data;
     size_t left_energy0_sizex = left_energy0_buffer.nX();
-#pragma omp target teams distribute parallel for simd clover_use_target(globals.context.use_target)
+#pragma acc parallel loop gang worker vector default(present) clover_use_target(globals.context.use_target)
     for (int k = (y_min - depth + 1); k < (y_max + depth + 2); k++) {
       for (int j = 0; j < depth; ++j) {
         energy0[(x_min - j) + (k)*energy0_sizex] = left_energy0[(left_xmax + 1 - j) + (k)*left_energy0_sizex];
@@ -99,7 +99,7 @@ void update_tile_halo_l_kernel(global_variables &globals, int x_min, int x_max, 
     size_t energy1_sizex = energy1_buffer.nX();
     double *left_energy1 = left_energy1_buffer.data;
     size_t left_energy1_sizex = left_energy1_buffer.nX();
-#pragma omp target teams distribute parallel for simd clover_use_target(globals.context.use_target)
+#pragma acc parallel loop gang worker vector default(present) clover_use_target(globals.context.use_target)
     for (int k = (y_min - depth + 1); k < (y_max + depth + 2); k++) {
       for (int j = 0; j < depth; ++j) {
         energy1[(x_min - j) + (k)*energy1_sizex] = left_energy1[(left_xmax + 1 - j) + (k)*left_energy1_sizex];
@@ -115,7 +115,7 @@ void update_tile_halo_l_kernel(global_variables &globals, int x_min, int x_max, 
     size_t pressure_sizex = pressure_buffer.nX();
     double *left_pressure = left_pressure_buffer.data;
     size_t left_pressure_sizex = left_pressure_buffer.nX();
-#pragma omp target teams distribute parallel for simd clover_use_target(globals.context.use_target)
+#pragma acc parallel loop gang worker vector default(present) clover_use_target(globals.context.use_target)
     for (int k = (y_min - depth + 1); k < (y_max + depth + 2); k++) {
       for (int j = 0; j < depth; ++j) {
         pressure[(x_min - j) + (k)*pressure_sizex] = left_pressure[(left_xmax + 1 - j) + (k)*left_pressure_sizex];
@@ -131,7 +131,7 @@ void update_tile_halo_l_kernel(global_variables &globals, int x_min, int x_max, 
     size_t viscosity_sizex = viscosity_buffer.nX();
     double *left_viscosity = left_viscosity_buffer.data;
     size_t left_viscosity_sizex = left_viscosity_buffer.nX();
-#pragma omp target teams distribute parallel for simd clover_use_target(globals.context.use_target)
+#pragma acc parallel loop gang worker vector default(present) clover_use_target(globals.context.use_target)
     for (int k = (y_min - depth + 1); k < (y_max + depth + 2); k++) {
       for (int j = 0; j < depth; ++j) {
         viscosity[(x_min - j) + (k)*viscosity_sizex] = left_viscosity[(left_xmax + 1 - j) + (k)*left_viscosity_sizex];
@@ -147,7 +147,7 @@ void update_tile_halo_l_kernel(global_variables &globals, int x_min, int x_max, 
     size_t soundspeed_sizex = soundspeed_buffer.nX();
     double *left_soundspeed = left_soundspeed_buffer.data;
     size_t left_soundspeed_sizex = left_soundspeed_buffer.nX();
-#pragma omp target teams distribute parallel for simd clover_use_target(globals.context.use_target)
+#pragma acc parallel loop gang worker vector default(present) clover_use_target(globals.context.use_target)
     for (int k = (y_min - depth + 1); k < (y_max + depth + 2); k++) {
       for (int j = 0; j < depth; ++j) {
         soundspeed[(x_min - j) + (k)*soundspeed_sizex] = left_soundspeed[(left_xmax + 1 - j) + (k)*left_soundspeed_sizex];
@@ -163,7 +163,7 @@ void update_tile_halo_l_kernel(global_variables &globals, int x_min, int x_max, 
     size_t xvel0_sizex = xvel0_buffer.nX();
     double *left_xvel0 = left_xvel0_buffer.data;
     size_t left_xvel0_sizex = left_xvel0_buffer.nX();
-#pragma omp target teams distribute parallel for simd clover_use_target(globals.context.use_target)
+#pragma acc parallel loop gang worker vector default(present) clover_use_target(globals.context.use_target)
     for (int k = (y_min - depth + 1); k < (y_max + 1 + depth + 2); k++) {
       for (int j = 0; j < depth; ++j) {
         xvel0[(x_min - j) + (k)*xvel0_sizex] = left_xvel0[(left_xmax + 1 - j) + (k)*left_xvel0_sizex];
@@ -179,7 +179,7 @@ void update_tile_halo_l_kernel(global_variables &globals, int x_min, int x_max, 
     size_t xvel1_sizex = xvel1_buffer.nX();
     double *left_xvel1 = left_xvel1_buffer.data;
     size_t left_xvel1_sizex = left_xvel1_buffer.nX();
-#pragma omp target teams distribute parallel for simd clover_use_target(globals.context.use_target)
+#pragma acc parallel loop gang worker vector default(present) clover_use_target(globals.context.use_target)
     for (int k = (y_min - depth + 1); k < (y_max + 1 + depth + 2); k++) {
       for (int j = 0; j < depth; ++j) {
         xvel1[(x_min - j) + (k)*xvel1_sizex] = left_xvel1[(left_xmax + 1 - j) + (k)*left_xvel1_sizex];
@@ -195,7 +195,7 @@ void update_tile_halo_l_kernel(global_variables &globals, int x_min, int x_max, 
     size_t yvel0_sizex = yvel0_buffer.nX();
     double *left_yvel0 = left_yvel0_buffer.data;
     size_t left_yvel0_sizex = left_yvel0_buffer.nX();
-#pragma omp target teams distribute parallel for simd clover_use_target(globals.context.use_target)
+#pragma acc parallel loop gang worker vector default(present) clover_use_target(globals.context.use_target)
     for (int k = (y_min - depth + 1); k < (y_max + 1 + depth + 2); k++) {
       for (int j = 0; j < depth; ++j) {
         yvel0[(x_min - j) + (k)*yvel0_sizex] = left_yvel0[(left_xmax + 1 - j) + (k)*left_yvel0_sizex];
@@ -211,7 +211,7 @@ void update_tile_halo_l_kernel(global_variables &globals, int x_min, int x_max, 
     size_t yvel1_sizex = yvel1_buffer.nX();
     double *left_yvel1 = left_yvel1_buffer.data;
     size_t left_yvel1_sizex = left_yvel1_buffer.nX();
-#pragma omp target teams distribute parallel for simd clover_use_target(globals.context.use_target)
+#pragma acc parallel loop gang worker vector default(present) clover_use_target(globals.context.use_target)
     for (int k = (y_min - depth + 1); k < (y_max + 1 + depth + 2); k++) {
       for (int j = 0; j < depth; ++j) {
         yvel1[(x_min - j) + (k)*yvel1_sizex] = left_yvel1[(left_xmax + 1 - j) + (k)*left_yvel1_sizex];
@@ -227,7 +227,7 @@ void update_tile_halo_l_kernel(global_variables &globals, int x_min, int x_max, 
     size_t vol_flux_x_sizex = vol_flux_x_buffer.nX();
     double *left_vol_flux_x = left_vol_flux_x_buffer.data;
     size_t left_vol_flux_x_sizex = left_vol_flux_x_buffer.nX();
-#pragma omp target teams distribute parallel for simd clover_use_target(globals.context.use_target)
+#pragma acc parallel loop gang worker vector default(present) clover_use_target(globals.context.use_target)
     for (int k = (y_min - depth + 1); k < (y_max + depth + 2); k++) {
       for (int j = 0; j < depth; ++j) {
         vol_flux_x[(x_min - j) + (k)*vol_flux_x_sizex] = left_vol_flux_x[(left_xmax + 1 - j) + (k)*left_vol_flux_x_sizex];
@@ -243,7 +243,7 @@ void update_tile_halo_l_kernel(global_variables &globals, int x_min, int x_max, 
     size_t mass_flux_x_sizex = mass_flux_x_buffer.nX();
     double *left_mass_flux_x = left_mass_flux_x_buffer.data;
     size_t left_mass_flux_x_sizex = left_mass_flux_x_buffer.nX();
-#pragma omp target teams distribute parallel for simd clover_use_target(globals.context.use_target)
+#pragma acc parallel loop gang worker vector default(present) clover_use_target(globals.context.use_target)
     for (int k = (y_min - depth + 1); k < (y_max + depth + 2); k++) {
       for (int j = 0; j < depth; ++j) {
         mass_flux_x[(x_min - j) + (k)*mass_flux_x_sizex] = left_mass_flux_x[(left_xmax + 1 - j) + (k)*left_mass_flux_x_sizex];
@@ -259,7 +259,7 @@ void update_tile_halo_l_kernel(global_variables &globals, int x_min, int x_max, 
     size_t vol_flux_y_sizex = vol_flux_y_buffer.nX();
     double *left_vol_flux_y = left_vol_flux_y_buffer.data;
     size_t left_vol_flux_y_sizex = left_vol_flux_y_buffer.nX();
-#pragma omp target teams distribute parallel for simd clover_use_target(globals.context.use_target)
+#pragma acc parallel loop gang worker vector default(present) clover_use_target(globals.context.use_target)
     for (int k = (y_min - depth + 1); k < (y_max + 1 + depth + 2); k++) {
       for (int j = 0; j < depth; ++j) {
         vol_flux_y[(x_min - j) + (k)*vol_flux_y_sizex] = left_vol_flux_y[(left_xmax + 1 - j) + (k)*left_vol_flux_y_sizex];
@@ -275,7 +275,7 @@ void update_tile_halo_l_kernel(global_variables &globals, int x_min, int x_max, 
     size_t mass_flux_y_sizex = mass_flux_y_buffer.nX();
     double *left_mass_flux_y = left_mass_flux_y_buffer.data;
     size_t left_mass_flux_y_sizex = left_mass_flux_y_buffer.nX();
-#pragma omp target teams distribute parallel for simd clover_use_target(globals.context.use_target)
+#pragma acc parallel loop gang worker vector default(present) clover_use_target(globals.context.use_target)
     for (int k = (y_min - depth + 1); k < (y_max + 1 + depth + 2); k++) {
       for (int j = 0; j < depth; ++j) {
         mass_flux_y[(x_min - j) + (k)*mass_flux_y_sizex] = left_mass_flux_y[(left_xmax + 1 - j) + (k)*left_mass_flux_y_sizex];
@@ -309,7 +309,7 @@ void update_tile_halo_r_kernel(global_variables &globals, int x_min, int x_max, 
     size_t density0_sizex = density0_buffer.nX();
     double *right_density0 = right_density0_buffer.data;
     size_t right_density0_sizex = right_density0_buffer.nX();
-#pragma omp target teams distribute parallel for simd clover_use_target(globals.context.use_target)
+#pragma acc parallel loop gang worker vector default(present) clover_use_target(globals.context.use_target)
     for (int k = (y_min - depth + 1); k < (y_max + depth + 2); k++) {
       for (int j = 0; j < depth; ++j) {
         density0[(x_max + 2 + j) + (k)*density0_sizex] = right_density0[(right_xmin - 1 + 2 + j) + (k)*right_density0_sizex];
@@ -325,7 +325,7 @@ void update_tile_halo_r_kernel(global_variables &globals, int x_min, int x_max, 
     size_t density1_sizex = density1_buffer.nX();
     double *right_density1 = right_density1_buffer.data;
     size_t right_density1_sizex = right_density1_buffer.nX();
-#pragma omp target teams distribute parallel for simd clover_use_target(globals.context.use_target)
+#pragma acc parallel loop gang worker vector default(present) clover_use_target(globals.context.use_target)
     for (int k = (y_min - depth + 1); k < (y_max + depth + 2); k++) {
       for (int j = 0; j < depth; ++j) {
         density1[(x_max + 2 + j) + (k)*density1_sizex] = right_density1[(right_xmin - 1 + 2 + j) + (k)*right_density1_sizex];
@@ -341,7 +341,7 @@ void update_tile_halo_r_kernel(global_variables &globals, int x_min, int x_max, 
     size_t energy0_sizex = energy0_buffer.nX();
     double *right_energy0 = right_energy0_buffer.data;
     size_t right_energy0_sizex = right_energy0_buffer.nX();
-#pragma omp target teams distribute parallel for simd clover_use_target(globals.context.use_target)
+#pragma acc parallel loop gang worker vector default(present) clover_use_target(globals.context.use_target)
     for (int k = (y_min - depth + 1); k < (y_max + depth + 2); k++) {
       for (int j = 0; j < depth; ++j) {
         energy0[(x_max + 2 + j) + (k)*energy0_sizex] = right_energy0[(right_xmin - 1 + 2 + j) + (k)*right_energy0_sizex];
@@ -357,7 +357,7 @@ void update_tile_halo_r_kernel(global_variables &globals, int x_min, int x_max, 
     size_t energy1_sizex = energy1_buffer.nX();
     double *right_energy1 = right_energy1_buffer.data;
     size_t right_energy1_sizex = right_energy1_buffer.nX();
-#pragma omp target teams distribute parallel for simd clover_use_target(globals.context.use_target)
+#pragma acc parallel loop gang worker vector default(present) clover_use_target(globals.context.use_target)
     for (int k = (y_min - depth + 1); k < (y_max + depth + 2); k++) {
       for (int j = 0; j < depth; ++j) {
         energy1[(x_max + 2 + j) + (k)*energy1_sizex] = right_energy1[(right_xmin - 1 + 2 + j) + (k)*right_energy1_sizex];
@@ -373,7 +373,7 @@ void update_tile_halo_r_kernel(global_variables &globals, int x_min, int x_max, 
     size_t pressure_sizex = pressure_buffer.nX();
     double *right_pressure = right_pressure_buffer.data;
     size_t right_pressure_sizex = right_pressure_buffer.nX();
-#pragma omp target teams distribute parallel for simd clover_use_target(globals.context.use_target)
+#pragma acc parallel loop gang worker vector default(present) clover_use_target(globals.context.use_target)
     for (int k = (y_min - depth + 1); k < (y_max + depth + 2); k++) {
       for (int j = 0; j < depth; ++j) {
         pressure[(x_max + 2 + j) + (k)*pressure_sizex] = right_pressure[(right_xmin - 1 + 2 + j) + (k)*right_pressure_sizex];
@@ -389,7 +389,7 @@ void update_tile_halo_r_kernel(global_variables &globals, int x_min, int x_max, 
     size_t viscosity_sizex = viscosity_buffer.nX();
     double *right_viscosity = right_viscosity_buffer.data;
     size_t right_viscosity_sizex = right_viscosity_buffer.nX();
-#pragma omp target teams distribute parallel for simd clover_use_target(globals.context.use_target)
+#pragma acc parallel loop gang worker vector default(present) clover_use_target(globals.context.use_target)
     for (int k = (y_min - depth + 1); k < (y_max + depth + 2); k++) {
       for (int j = 0; j < depth; ++j) {
         viscosity[(x_max + 2 + j) + (k)*viscosity_sizex] = right_viscosity[(right_xmin - 1 + 2 + j) + (k)*right_viscosity_sizex];
@@ -405,7 +405,7 @@ void update_tile_halo_r_kernel(global_variables &globals, int x_min, int x_max, 
     size_t soundspeed_sizex = soundspeed_buffer.nX();
     double *right_soundspeed = right_soundspeed_buffer.data;
     size_t right_soundspeed_sizex = right_soundspeed_buffer.nX();
-#pragma omp target teams distribute parallel for simd clover_use_target(globals.context.use_target)
+#pragma acc parallel loop gang worker vector default(present) clover_use_target(globals.context.use_target)
     for (int k = (y_min - depth + 1); k < (y_max + depth + 2); k++) {
       for (int j = 0; j < depth; ++j) {
         soundspeed[(x_max + 2 + j) + (k)*soundspeed_sizex] = right_soundspeed[(right_xmin - 1 + 2 + j) + (k)*right_soundspeed_sizex];
@@ -421,7 +421,7 @@ void update_tile_halo_r_kernel(global_variables &globals, int x_min, int x_max, 
     size_t xvel0_sizex = xvel0_buffer.nX();
     double *right_xvel0 = right_xvel0_buffer.data;
     size_t right_xvel0_sizex = right_xvel0_buffer.nX();
-#pragma omp target teams distribute parallel for simd clover_use_target(globals.context.use_target)
+#pragma acc parallel loop gang worker vector default(present) clover_use_target(globals.context.use_target)
     for (int k = (y_min - depth + 1); k < (y_max + 1 + depth + 2); k++) {
       for (int j = 0; j < depth; ++j) {
         xvel0[(x_max + 1 + 2 + j) + (k)*xvel0_sizex] = right_xvel0[(right_xmin + 1 - 1 + 2 + j) + (k)*right_xvel0_sizex];
@@ -437,7 +437,7 @@ void update_tile_halo_r_kernel(global_variables &globals, int x_min, int x_max, 
     size_t xvel1_sizex = xvel1_buffer.nX();
     double *right_xvel1 = right_xvel1_buffer.data;
     size_t right_xvel1_sizex = right_xvel1_buffer.nX();
-#pragma omp target teams distribute parallel for simd clover_use_target(globals.context.use_target)
+#pragma acc parallel loop gang worker vector default(present) clover_use_target(globals.context.use_target)
     for (int k = (y_min - depth + 1); k < (y_max + 1 + depth + 2); k++) {
       for (int j = 0; j < depth; ++j) {
         xvel1[(x_max + 1 + 2 + j) + (k)*xvel1_sizex] = right_xvel1[(right_xmin + 1 - 1 + 2 + j) + (k)*right_xvel1_sizex];
@@ -453,7 +453,7 @@ void update_tile_halo_r_kernel(global_variables &globals, int x_min, int x_max, 
     size_t yvel0_sizex = yvel0_buffer.nX();
     double *right_yvel0 = right_yvel0_buffer.data;
     size_t right_yvel0_sizex = right_yvel0_buffer.nX();
-#pragma omp target teams distribute parallel for simd clover_use_target(globals.context.use_target)
+#pragma acc parallel loop gang worker vector default(present) clover_use_target(globals.context.use_target)
     for (int k = (y_min - depth + 1); k < (y_max + 1 + depth + 2); k++) {
       for (int j = 0; j < depth; ++j) {
         yvel0[(x_max + 1 + 2 + j) + (k)*yvel0_sizex] = right_yvel0[(right_xmin + 1 - 1 + 2 + j) + (k)*right_yvel0_sizex];
@@ -469,7 +469,7 @@ void update_tile_halo_r_kernel(global_variables &globals, int x_min, int x_max, 
     size_t yvel1_sizex = yvel1_buffer.nX();
     double *right_yvel1 = right_yvel1_buffer.data;
     size_t right_yvel1_sizex = right_yvel1_buffer.nX();
-#pragma omp target teams distribute parallel for simd clover_use_target(globals.context.use_target)
+#pragma acc parallel loop gang worker vector default(present) clover_use_target(globals.context.use_target)
     for (int k = (y_min - depth + 1); k < (y_max + 1 + depth + 2); k++) {
       for (int j = 0; j < depth; ++j) {
         yvel1[(x_max + 1 + 2 + j) + (k)*yvel1_sizex] = right_yvel1[(right_xmin + 1 - 1 + 2 + j) + (k)*right_yvel1_sizex];
@@ -485,7 +485,7 @@ void update_tile_halo_r_kernel(global_variables &globals, int x_min, int x_max, 
     size_t vol_flux_x_sizex = vol_flux_x_buffer.nX();
     double *right_vol_flux_x = right_vol_flux_x_buffer.data;
     size_t right_vol_flux_x_sizex = right_vol_flux_x_buffer.nX();
-#pragma omp target teams distribute parallel for simd clover_use_target(globals.context.use_target)
+#pragma acc parallel loop gang worker vector default(present) clover_use_target(globals.context.use_target)
     for (int k = (y_min - depth + 1); k < (y_max + depth + 2); k++) {
       for (int j = 0; j < depth; ++j) {
         vol_flux_x[(x_max + 1 + 2 + j) + (k)*vol_flux_x_sizex] =
@@ -502,7 +502,7 @@ void update_tile_halo_r_kernel(global_variables &globals, int x_min, int x_max, 
     size_t mass_flux_x_sizex = mass_flux_x_buffer.nX();
     double *right_mass_flux_x = right_mass_flux_x_buffer.data;
     size_t right_mass_flux_x_sizex = right_mass_flux_x_buffer.nX();
-#pragma omp target teams distribute parallel for simd clover_use_target(globals.context.use_target)
+#pragma acc parallel loop gang worker vector default(present) clover_use_target(globals.context.use_target)
     for (int k = (y_min - depth + 1); k < (y_max + depth + 2); k++) {
       for (int j = 0; j < depth; ++j) {
         mass_flux_x[(x_max + 1 + 2 + j) + (k)*mass_flux_x_sizex] =
@@ -519,7 +519,7 @@ void update_tile_halo_r_kernel(global_variables &globals, int x_min, int x_max, 
     size_t vol_flux_y_sizex = vol_flux_y_buffer.nX();
     double *right_vol_flux_y = right_vol_flux_y_buffer.data;
     size_t right_vol_flux_y_sizex = right_vol_flux_y_buffer.nX();
-#pragma omp target teams distribute parallel for simd clover_use_target(globals.context.use_target)
+#pragma acc parallel loop gang worker vector default(present) clover_use_target(globals.context.use_target)
     for (int k = (y_min - depth + 1); k < (y_max + 1 + depth + 2); k++) {
       for (int j = 0; j < depth; ++j) {
         vol_flux_y[(x_max + 2 + j) + (k)*vol_flux_y_sizex] = right_vol_flux_y[(right_xmin - 1 + 2 + j) + (k)*right_vol_flux_y_sizex];
@@ -535,7 +535,7 @@ void update_tile_halo_r_kernel(global_variables &globals, int x_min, int x_max, 
     size_t mass_flux_y_sizex = mass_flux_y_buffer.nX();
     double *right_mass_flux_y = right_mass_flux_y_buffer.data;
     size_t right_mass_flux_y_sizex = right_mass_flux_y_buffer.nX();
-#pragma omp target teams distribute parallel for simd clover_use_target(globals.context.use_target)
+#pragma acc parallel loop gang worker vector default(present) clover_use_target(globals.context.use_target)
     for (int k = (y_min - depth + 1); k < (y_max + 1 + depth + 2); k++) {
       for (int j = 0; j < depth; ++j) {
         mass_flux_y[(x_max + 2 + j) + (k)*mass_flux_y_sizex] = right_mass_flux_y[(right_xmin - 1 + 2 + j) + (k)*right_mass_flux_y_sizex];
@@ -571,7 +571,7 @@ void update_tile_halo_t_kernel(
       size_t density0_sizex = density0_buffer.nX();
       double *top_density0 = top_density0_buffer.data;
       size_t top_density0_sizex = top_density0_buffer.nX();
-#pragma omp target teams distribute parallel for simd clover_use_target(globals.context.use_target)
+#pragma acc parallel loop gang worker vector default(present) clover_use_target(globals.context.use_target)
       for (int j = (x_min - depth + 1); j < (x_max + depth + 2); j++) {
         density0[j + (y_max + 2 + k) * density0_sizex] = top_density0[j + (top_ymin - 1 + 2 + k) * top_density0_sizex];
       }
@@ -587,7 +587,7 @@ void update_tile_halo_t_kernel(
       size_t density1_sizex = density1_buffer.nX();
       double *top_density1 = top_density1_buffer.data;
       size_t top_density1_sizex = top_density1_buffer.nX();
-#pragma omp target teams distribute parallel for simd clover_use_target(globals.context.use_target)
+#pragma acc parallel loop gang worker vector default(present) clover_use_target(globals.context.use_target)
       for (int j = (x_min - depth + 1); j < (x_max + depth + 2); j++) {
         density1[j + (y_max + 2 + k) * density1_sizex] = top_density1[j + (top_ymin - 1 + 2 + k) * top_density1_sizex];
       }
@@ -603,7 +603,7 @@ void update_tile_halo_t_kernel(
       size_t energy0_sizex = energy0_buffer.nX();
       double *top_energy0 = top_energy0_buffer.data;
       size_t top_energy0_sizex = top_energy0_buffer.nX();
-#pragma omp target teams distribute parallel for simd clover_use_target(globals.context.use_target)
+#pragma acc parallel loop gang worker vector default(present) clover_use_target(globals.context.use_target)
       for (int j = (x_min - depth + 1); j < (x_max + depth + 2); j++) {
         energy0[j + (y_max + 2 + k) * energy0_sizex] = top_energy0[j + (top_ymin - 1 + 2 + k) * top_energy0_sizex];
       }
@@ -619,7 +619,7 @@ void update_tile_halo_t_kernel(
       size_t energy1_sizex = energy1_buffer.nX();
       double *top_energy1 = top_energy1_buffer.data;
       size_t top_energy1_sizex = top_energy1_buffer.nX();
-#pragma omp target teams distribute parallel for simd clover_use_target(globals.context.use_target)
+#pragma acc parallel loop gang worker vector default(present) clover_use_target(globals.context.use_target)
       for (int j = (x_min - depth + 1); j < (x_max + depth + 2); j++) {
         energy1[j + (y_max + 2 + k) * energy1_sizex] = top_energy1[j + (top_ymin - 1 + 2 + k) * top_energy1_sizex];
       }
@@ -635,7 +635,7 @@ void update_tile_halo_t_kernel(
       size_t pressure_sizex = pressure_buffer.nX();
       double *top_pressure = top_pressure_buffer.data;
       size_t top_pressure_sizex = top_pressure_buffer.nX();
-#pragma omp target teams distribute parallel for simd clover_use_target(globals.context.use_target)
+#pragma acc parallel loop gang worker vector default(present) clover_use_target(globals.context.use_target)
       for (int j = (x_min - depth + 1); j < (x_max + depth + 2); j++) {
         pressure[j + (y_max + 2 + k) * pressure_sizex] = top_pressure[j + (top_ymin - 1 + 2 + k) * top_pressure_sizex];
       }
@@ -651,7 +651,7 @@ void update_tile_halo_t_kernel(
       size_t viscosity_sizex = viscosity_buffer.nX();
       double *top_viscosity = top_viscosity_buffer.data;
       size_t top_viscosity_sizex = top_viscosity_buffer.nX();
-#pragma omp target teams distribute parallel for simd clover_use_target(globals.context.use_target)
+#pragma acc parallel loop gang worker vector default(present) clover_use_target(globals.context.use_target)
       for (int j = (x_min - depth + 1); j < (x_max + depth + 2); j++) {
         viscosity[j + (y_max + 2 + k) * viscosity_sizex] = top_viscosity[j + (top_ymin - 1 + 2 + k) * top_viscosity_sizex];
       }
@@ -667,7 +667,7 @@ void update_tile_halo_t_kernel(
       size_t soundspeed_sizex = soundspeed_buffer.nX();
       double *top_soundspeed = top_soundspeed_buffer.data;
       size_t top_soundspeed_sizex = top_soundspeed_buffer.nX();
-#pragma omp target teams distribute parallel for simd clover_use_target(globals.context.use_target)
+#pragma acc parallel loop gang worker vector default(present) clover_use_target(globals.context.use_target)
       for (int j = (x_min - depth + 1); j < (x_max + depth + 2); j++) {
         soundspeed[j + (y_max + 2 + k) * soundspeed_sizex] = top_soundspeed[j + (top_ymin - 1 + 2 + k) * top_soundspeed_sizex];
       }
@@ -683,7 +683,7 @@ void update_tile_halo_t_kernel(
       size_t xvel0_sizex = xvel0_buffer.nX();
       double *top_xvel0 = top_xvel0_buffer.data;
       size_t top_xvel0_sizex = top_xvel0_buffer.nX();
-#pragma omp target teams distribute parallel for simd clover_use_target(globals.context.use_target)
+#pragma acc parallel loop gang worker vector default(present) clover_use_target(globals.context.use_target)
       for (int j = (x_min - depth + 1); j < (x_max + 1 + depth + 2); j++) {
         xvel0[j + (y_max + 1 + 2 + k) * xvel0_sizex] = top_xvel0[j + (top_ymin + 1 - 1 + 2 + k) * top_xvel0_sizex];
       }
@@ -699,7 +699,7 @@ void update_tile_halo_t_kernel(
       size_t xvel1_sizex = xvel1_buffer.nX();
       double *top_xvel1 = top_xvel1_buffer.data;
       size_t top_xvel1_sizex = top_xvel1_buffer.nX();
-#pragma omp target teams distribute parallel for simd clover_use_target(globals.context.use_target)
+#pragma acc parallel loop gang worker vector default(present) clover_use_target(globals.context.use_target)
       for (int j = (x_min - depth + 1); j < (x_max + 1 + depth + 2); j++) {
         xvel1[j + (y_max + 1 + 2 + k) * xvel1_sizex] = top_xvel1[j + (top_ymin + 1 - 1 + 2 + k) * top_xvel1_sizex];
       }
@@ -715,7 +715,7 @@ void update_tile_halo_t_kernel(
       size_t yvel0_sizex = yvel0_buffer.nX();
       double *top_yvel0 = top_yvel0_buffer.data;
       size_t top_yvel0_sizex = top_yvel0_buffer.nX();
-#pragma omp target teams distribute parallel for simd clover_use_target(globals.context.use_target)
+#pragma acc parallel loop gang worker vector default(present) clover_use_target(globals.context.use_target)
       for (int j = (x_min - depth + 1); j < (x_max + 1 + depth + 2); j++) {
         yvel0[j + (y_max + 1 + 2 + k) * yvel0_sizex] = top_yvel0[j + (top_ymin + 1 - 1 + 2 + k) * top_yvel0_sizex];
       }
@@ -731,7 +731,7 @@ void update_tile_halo_t_kernel(
       size_t yvel1_sizex = yvel1_buffer.nX();
       double *top_yvel1 = top_yvel1_buffer.data;
       size_t top_yvel1_sizex = top_yvel1_buffer.nX();
-#pragma omp target teams distribute parallel for simd clover_use_target(globals.context.use_target)
+#pragma acc parallel loop gang worker vector default(present) clover_use_target(globals.context.use_target)
       for (int j = (x_min - depth + 1); j < (x_max + 1 + depth + 2); j++) {
         yvel1[j + (y_max + 1 + 2 + k) * yvel1_sizex] = top_yvel1[j + (top_ymin + 1 - 1 + 2 + k) * top_yvel1_sizex];
       }
@@ -747,7 +747,7 @@ void update_tile_halo_t_kernel(
       size_t vol_flux_x_sizex = vol_flux_x_buffer.nX();
       double *top_vol_flux_x = top_vol_flux_x_buffer.data;
       size_t top_vol_flux_x_sizex = top_vol_flux_x_buffer.nX();
-#pragma omp target teams distribute parallel for simd clover_use_target(globals.context.use_target)
+#pragma acc parallel loop gang worker vector default(present) clover_use_target(globals.context.use_target)
       for (int j = (x_min - depth + 1); j < (x_max + 1 + depth + 2); j++) {
         vol_flux_x[j + (y_max + 2 + k) * vol_flux_x_sizex] = top_vol_flux_x[j + (top_ymin - 1 + 2 + k) * top_vol_flux_x_sizex];
       }
@@ -763,7 +763,7 @@ void update_tile_halo_t_kernel(
       size_t mass_flux_x_sizex = mass_flux_x_buffer.nX();
       double *top_mass_flux_x = top_mass_flux_x_buffer.data;
       size_t top_mass_flux_x_sizex = top_mass_flux_x_buffer.nX();
-#pragma omp target teams distribute parallel for simd clover_use_target(globals.context.use_target)
+#pragma acc parallel loop gang worker vector default(present) clover_use_target(globals.context.use_target)
       for (int j = (x_min - depth + 1); j < (x_max + 1 + depth + 2); j++) {
         mass_flux_x[j + (y_max + 2 + k) * mass_flux_x_sizex] = top_mass_flux_x[j + (top_ymin - 1 + 2 + k) * top_mass_flux_x_sizex];
       }
@@ -779,7 +779,7 @@ void update_tile_halo_t_kernel(
       size_t vol_flux_y_sizex = vol_flux_y_buffer.nX();
       double *top_vol_flux_y = top_vol_flux_y_buffer.data;
       size_t top_vol_flux_y_sizex = top_vol_flux_y_buffer.nX();
-#pragma omp target teams distribute parallel for simd clover_use_target(globals.context.use_target)
+#pragma acc parallel loop gang worker vector default(present) clover_use_target(globals.context.use_target)
       for (int j = (x_min - depth + 1); j < (x_max + depth + 2); j++) {
         vol_flux_y[j + (y_max + 1 + 2 + k) * vol_flux_y_sizex] = top_vol_flux_y[j + (top_ymin + 1 - 1 + 2 + k) * top_vol_flux_y_sizex];
       }
@@ -795,7 +795,7 @@ void update_tile_halo_t_kernel(
       size_t mass_flux_y_sizex = mass_flux_y_buffer.nX();
       double *top_mass_flux_y = top_mass_flux_y_buffer.data;
       size_t top_mass_flux_y_sizex = top_mass_flux_y_buffer.nX();
-#pragma omp target teams distribute parallel for simd clover_use_target(globals.context.use_target)
+#pragma acc parallel loop gang worker vector default(present) clover_use_target(globals.context.use_target)
       for (int j = (x_min - depth + 1); j < (x_max + depth + 2); j++) {
         mass_flux_y[j + (y_max + 1 + 2 + k) * mass_flux_y_sizex] = top_mass_flux_y[j + (top_ymin + 1 - 1 + 2 + k) * top_mass_flux_y_sizex];
       }
@@ -827,7 +827,7 @@ void update_tile_halo_b_kernel(
       size_t density0_sizex = density0_buffer.nX();
       double *bottom_density0 = bottom_density0_buffer.data;
       size_t bottom_density0_sizex = bottom_density0_buffer.nX();
-#pragma omp target teams distribute parallel for simd clover_use_target(globals.context.use_target)
+#pragma acc parallel loop gang worker vector default(present) clover_use_target(globals.context.use_target)
       for (int j = (x_min - depth + 1); j < (x_max + depth + 2); j++) {
         density0[j + (y_min - k) * density0_sizex] = bottom_density0[j + (bottom_ymax + 1 - k) * bottom_density0_sizex];
       }
@@ -843,7 +843,7 @@ void update_tile_halo_b_kernel(
       size_t density1_sizex = density1_buffer.nX();
       double *bottom_density1 = bottom_density1_buffer.data;
       size_t bottom_density1_sizex = bottom_density1_buffer.nX();
-#pragma omp target teams distribute parallel for simd clover_use_target(globals.context.use_target)
+#pragma acc parallel loop gang worker vector default(present) clover_use_target(globals.context.use_target)
       for (int j = (x_min - depth + 1); j < (x_max + depth + 2); j++) {
         density1[j + (y_min - k) * density1_sizex] = bottom_density1[j + (bottom_ymax + 1 - k) * bottom_density1_sizex];
       }
@@ -859,7 +859,7 @@ void update_tile_halo_b_kernel(
       size_t energy0_sizex = energy0_buffer.nX();
       double *bottom_energy0 = bottom_energy0_buffer.data;
       size_t bottom_energy0_sizex = bottom_energy0_buffer.nX();
-#pragma omp target teams distribute parallel for simd clover_use_target(globals.context.use_target)
+#pragma acc parallel loop gang worker vector default(present) clover_use_target(globals.context.use_target)
       for (int j = (x_min - depth + 1); j < (x_max + depth + 2); j++) {
         energy0[j + (y_min - k) * energy0_sizex] = bottom_energy0[j + (bottom_ymax + 1 - k) * bottom_energy0_sizex];
       }
@@ -875,7 +875,7 @@ void update_tile_halo_b_kernel(
       size_t energy1_sizex = energy1_buffer.nX();
       double *bottom_energy1 = bottom_energy1_buffer.data;
       size_t bottom_energy1_sizex = bottom_energy1_buffer.nX();
-#pragma omp target teams distribute parallel for simd clover_use_target(globals.context.use_target)
+#pragma acc parallel loop gang worker vector default(present) clover_use_target(globals.context.use_target)
       for (int j = (x_min - depth + 1); j < (x_max + depth + 2); j++) {
         energy1[j + (y_min - k) * energy1_sizex] = bottom_energy1[j + (bottom_ymax + 1 - k) * bottom_energy1_sizex];
       }
@@ -891,7 +891,7 @@ void update_tile_halo_b_kernel(
       size_t pressure_sizex = pressure_buffer.nX();
       double *bottom_pressure = bottom_pressure_buffer.data;
       size_t bottom_pressure_sizex = bottom_pressure_buffer.nX();
-#pragma omp target teams distribute parallel for simd clover_use_target(globals.context.use_target)
+#pragma acc parallel loop gang worker vector default(present) clover_use_target(globals.context.use_target)
       for (int j = (x_min - depth + 1); j < (x_max + depth + 2); j++) {
         pressure[j + (y_min - k) * pressure_sizex] = bottom_pressure[j + (bottom_ymax + 1 - k) * bottom_pressure_sizex];
       }
@@ -907,7 +907,7 @@ void update_tile_halo_b_kernel(
       size_t viscosity_sizex = viscosity_buffer.nX();
       double *bottom_viscosity = bottom_viscosity_buffer.data;
       size_t bottom_viscosity_sizex = bottom_viscosity_buffer.nX();
-#pragma omp target teams distribute parallel for simd clover_use_target(globals.context.use_target)
+#pragma acc parallel loop gang worker vector default(present) clover_use_target(globals.context.use_target)
       for (int j = (x_min - depth + 1); j < (x_max + depth + 2); j++) {
         viscosity[j + (y_min - k) * viscosity_sizex] = bottom_viscosity[j + (bottom_ymax + 1 - k) * bottom_viscosity_sizex];
       }
@@ -923,7 +923,7 @@ void update_tile_halo_b_kernel(
       size_t soundspeed_sizex = soundspeed_buffer.nX();
       double *bottom_soundspeed = bottom_soundspeed_buffer.data;
       size_t bottom_soundspeed_sizex = bottom_soundspeed_buffer.nX();
-#pragma omp target teams distribute parallel for simd clover_use_target(globals.context.use_target)
+#pragma acc parallel loop gang worker vector default(present) clover_use_target(globals.context.use_target)
       for (int j = (x_min - depth + 1); j < (x_max + depth + 2); j++) {
         soundspeed[j + (y_min - k) * soundspeed_sizex] = bottom_soundspeed[j + (bottom_ymax + 1 - k) * bottom_soundspeed_sizex];
       }
@@ -939,7 +939,7 @@ void update_tile_halo_b_kernel(
       size_t xvel0_sizex = xvel0_buffer.nX();
       double *bottom_xvel0 = bottom_xvel0_buffer.data;
       size_t bottom_xvel0_sizex = bottom_xvel0_buffer.nX();
-#pragma omp target teams distribute parallel for simd clover_use_target(globals.context.use_target)
+#pragma acc parallel loop gang worker vector default(present) clover_use_target(globals.context.use_target)
       for (int j = (x_min - depth + 1); j < (x_max + 1 + depth + 2); j++) {
         xvel0[j + (y_min - k) * xvel0_sizex] = bottom_xvel0[j + (bottom_ymax + 1 - k) * bottom_xvel0_sizex];
       }
@@ -955,7 +955,7 @@ void update_tile_halo_b_kernel(
       size_t xvel1_sizex = xvel1_buffer.nX();
       double *bottom_xvel1 = bottom_xvel1_buffer.data;
       size_t bottom_xvel1_sizex = bottom_xvel1_buffer.nX();
-#pragma omp target teams distribute parallel for simd clover_use_target(globals.context.use_target)
+#pragma acc parallel loop gang worker vector default(present) clover_use_target(globals.context.use_target)
       for (int j = (x_min - depth + 1); j < (x_max + 1 + depth + 2); j++) {
         xvel1[j + (y_min - k) * xvel1_sizex] = bottom_xvel1[j + (bottom_ymax + 1 - k) * bottom_xvel1_sizex];
       }
@@ -971,7 +971,7 @@ void update_tile_halo_b_kernel(
       size_t yvel0_sizex = yvel0_buffer.nX();
       double *bottom_yvel0 = bottom_yvel0_buffer.data;
       size_t bottom_yvel0_sizex = bottom_yvel0_buffer.nX();
-#pragma omp target teams distribute parallel for simd clover_use_target(globals.context.use_target)
+#pragma acc parallel loop gang worker vector default(present) clover_use_target(globals.context.use_target)
       for (int j = (x_min - depth + 1); j < (x_max + 1 + depth + 2); j++) {
         yvel0[j + (y_min - k) * yvel0_sizex] = bottom_yvel0[j + (bottom_ymax + 1 - k) * bottom_yvel0_sizex];
       }
@@ -987,7 +987,7 @@ void update_tile_halo_b_kernel(
       size_t yvel1_sizex = yvel1_buffer.nX();
       double *bottom_yvel1 = bottom_yvel1_buffer.data;
       size_t bottom_yvel1_sizex = bottom_yvel1_buffer.nX();
-#pragma omp target teams distribute parallel for simd clover_use_target(globals.context.use_target)
+#pragma acc parallel loop gang worker vector default(present) clover_use_target(globals.context.use_target)
       for (int j = (x_min - depth + 1); j < (x_max + 1 + depth + 2); j++) {
         yvel1[j + (y_min - k) * yvel1_sizex] = bottom_yvel1[j + (bottom_ymax + 1 - k) * bottom_yvel1_sizex];
       }
@@ -1003,7 +1003,7 @@ void update_tile_halo_b_kernel(
       size_t vol_flux_x_sizex = vol_flux_x_buffer.nX();
       double *bottom_vol_flux_x = bottom_vol_flux_x_buffer.data;
       size_t bottom_vol_flux_x_sizex = bottom_vol_flux_x_buffer.nX();
-#pragma omp target teams distribute parallel for simd clover_use_target(globals.context.use_target)
+#pragma acc parallel loop gang worker vector default(present) clover_use_target(globals.context.use_target)
       for (int j = (x_min - depth + 1); j < (x_max + 1 + depth + 2); j++) {
         vol_flux_x[j + (y_min - k) * vol_flux_x_sizex] = bottom_vol_flux_x[j + (bottom_ymax + 1 - k) * bottom_vol_flux_x_sizex];
       }
@@ -1019,7 +1019,7 @@ void update_tile_halo_b_kernel(
       size_t mass_flux_x_sizex = mass_flux_x_buffer.nX();
       double *bottom_mass_flux_x = bottom_mass_flux_x_buffer.data;
       size_t bottom_mass_flux_x_sizex = bottom_mass_flux_x_buffer.nX();
-#pragma omp target teams distribute parallel for simd clover_use_target(globals.context.use_target)
+#pragma acc parallel loop gang worker vector default(present) clover_use_target(globals.context.use_target)
       for (int j = (x_min - depth + 1); j < (x_max + 1 + depth + 2); j++) {
         mass_flux_x[j + (y_min - k) * mass_flux_x_sizex] = bottom_mass_flux_x[j + (bottom_ymax + 1 - k) * bottom_mass_flux_x_sizex];
       }
@@ -1035,7 +1035,7 @@ void update_tile_halo_b_kernel(
       size_t vol_flux_y_sizex = vol_flux_y_buffer.nX();
       double *bottom_vol_flux_y = bottom_vol_flux_y_buffer.data;
       size_t bottom_vol_flux_y_sizex = bottom_vol_flux_y_buffer.nX();
-#pragma omp target teams distribute parallel for simd clover_use_target(globals.context.use_target)
+#pragma acc parallel loop gang worker vector default(present) clover_use_target(globals.context.use_target)
       for (int j = (x_min - depth + 1); j < (x_max + depth + 2); j++) {
         vol_flux_y[j + (y_min - k) * vol_flux_y_sizex] = bottom_vol_flux_y[j + (bottom_ymax + 1 - k) * bottom_vol_flux_y_sizex];
       }
@@ -1051,7 +1051,7 @@ void update_tile_halo_b_kernel(
       size_t mass_flux_y_sizex = mass_flux_y_buffer.nX();
       double *bottom_mass_flux_y = bottom_mass_flux_y_buffer.data;
       size_t bottom_mass_flux_y_sizex = bottom_mass_flux_y_buffer.nX();
-#pragma omp target teams distribute parallel for simd clover_use_target(globals.context.use_target)
+#pragma acc parallel loop gang worker vector default(present) clover_use_target(globals.context.use_target)
       for (int j = (x_min - depth + 1); j < (x_max + depth + 2); j++) {
         mass_flux_y[j + (y_min - k) * mass_flux_y_sizex] = bottom_mass_flux_y[j + (bottom_ymax + 1 - k) * bottom_mass_flux_y_sizex];
       }

--- a/src/acc/update_tile_halo_kernel.cpp
+++ b/src/acc/update_tile_halo_kernel.cpp
@@ -51,7 +51,8 @@ void update_tile_halo_l_kernel(global_variables &globals, int x_min, int x_max, 
     size_t density0_sizex = density0_buffer.nX();
     double *left_density0 = left_density0_buffer.data;
     size_t left_density0_sizex = left_density0_buffer.nX();
-#pragma acc parallel loop gang worker vector default(present) clover_use_target(globals.context.use_target)
+#pragma acc parallel loop gang worker vector clover_use_target(globals.context.use_target) \
+    present(density0[ : density0_buffer.N()], left_density0[ : left_density0_buffer.N()])
     for (int k = (y_min - depth + 1); k < (y_max + depth + 2); k++) {
       for (int j = 0; j < depth; ++j) {
         density0[(x_min - j) + (k)*density0_sizex] = left_density0[(left_xmax + 1 - j) + (k)*left_density0_sizex];
@@ -67,7 +68,8 @@ void update_tile_halo_l_kernel(global_variables &globals, int x_min, int x_max, 
     size_t density1_sizex = density1_buffer.nX();
     double *left_density1 = left_density1_buffer.data;
     size_t left_density1_sizex = left_density1_buffer.nX();
-#pragma acc parallel loop gang worker vector default(present) clover_use_target(globals.context.use_target)
+#pragma acc parallel loop gang worker vector clover_use_target(globals.context.use_target) \
+    present(density1[ : density1_buffer.N()], left_density1[ : left_density1_buffer.N()])
     for (int k = (y_min - depth + 1); k < (y_max + depth + 2); k++) {
       for (int j = 0; j < depth; ++j) {
         density1[(x_min - j) + (k)*density1_sizex] = left_density1[(left_xmax + 1 - j) + (k)*left_density1_sizex];
@@ -83,7 +85,8 @@ void update_tile_halo_l_kernel(global_variables &globals, int x_min, int x_max, 
     size_t energy0_sizex = energy0_buffer.nX();
     double *left_energy0 = left_energy0_buffer.data;
     size_t left_energy0_sizex = left_energy0_buffer.nX();
-#pragma acc parallel loop gang worker vector default(present) clover_use_target(globals.context.use_target)
+#pragma acc parallel loop gang worker vector clover_use_target(globals.context.use_target) \
+    present(energy0[ : energy0_buffer.N()], left_energy0[ : left_energy0_buffer.N()])
     for (int k = (y_min - depth + 1); k < (y_max + depth + 2); k++) {
       for (int j = 0; j < depth; ++j) {
         energy0[(x_min - j) + (k)*energy0_sizex] = left_energy0[(left_xmax + 1 - j) + (k)*left_energy0_sizex];
@@ -99,7 +102,8 @@ void update_tile_halo_l_kernel(global_variables &globals, int x_min, int x_max, 
     size_t energy1_sizex = energy1_buffer.nX();
     double *left_energy1 = left_energy1_buffer.data;
     size_t left_energy1_sizex = left_energy1_buffer.nX();
-#pragma acc parallel loop gang worker vector default(present) clover_use_target(globals.context.use_target)
+#pragma acc parallel loop gang worker vector clover_use_target(globals.context.use_target) \
+    present(energy1[ : energy1_buffer.N()], left_energy1[ : left_energy1_buffer.N()])
     for (int k = (y_min - depth + 1); k < (y_max + depth + 2); k++) {
       for (int j = 0; j < depth; ++j) {
         energy1[(x_min - j) + (k)*energy1_sizex] = left_energy1[(left_xmax + 1 - j) + (k)*left_energy1_sizex];
@@ -115,7 +119,8 @@ void update_tile_halo_l_kernel(global_variables &globals, int x_min, int x_max, 
     size_t pressure_sizex = pressure_buffer.nX();
     double *left_pressure = left_pressure_buffer.data;
     size_t left_pressure_sizex = left_pressure_buffer.nX();
-#pragma acc parallel loop gang worker vector default(present) clover_use_target(globals.context.use_target)
+#pragma acc parallel loop gang worker vector clover_use_target(globals.context.use_target) \
+    present(pressure[ : pressure_buffer.N()], left_pressure[ : left_pressure_buffer.N()])
     for (int k = (y_min - depth + 1); k < (y_max + depth + 2); k++) {
       for (int j = 0; j < depth; ++j) {
         pressure[(x_min - j) + (k)*pressure_sizex] = left_pressure[(left_xmax + 1 - j) + (k)*left_pressure_sizex];
@@ -131,7 +136,8 @@ void update_tile_halo_l_kernel(global_variables &globals, int x_min, int x_max, 
     size_t viscosity_sizex = viscosity_buffer.nX();
     double *left_viscosity = left_viscosity_buffer.data;
     size_t left_viscosity_sizex = left_viscosity_buffer.nX();
-#pragma acc parallel loop gang worker vector default(present) clover_use_target(globals.context.use_target)
+#pragma acc parallel loop gang worker vector clover_use_target(globals.context.use_target) \
+    present(viscosity[ : viscosity_buffer.N()], left_viscosity[ : left_viscosity_buffer.N()])
     for (int k = (y_min - depth + 1); k < (y_max + depth + 2); k++) {
       for (int j = 0; j < depth; ++j) {
         viscosity[(x_min - j) + (k)*viscosity_sizex] = left_viscosity[(left_xmax + 1 - j) + (k)*left_viscosity_sizex];
@@ -147,7 +153,8 @@ void update_tile_halo_l_kernel(global_variables &globals, int x_min, int x_max, 
     size_t soundspeed_sizex = soundspeed_buffer.nX();
     double *left_soundspeed = left_soundspeed_buffer.data;
     size_t left_soundspeed_sizex = left_soundspeed_buffer.nX();
-#pragma acc parallel loop gang worker vector default(present) clover_use_target(globals.context.use_target)
+#pragma acc parallel loop gang worker vector clover_use_target(globals.context.use_target) \
+    present(soundspeed[ : soundspeed_buffer.N()], left_soundspeed[ : left_soundspeed_buffer.N()])
     for (int k = (y_min - depth + 1); k < (y_max + depth + 2); k++) {
       for (int j = 0; j < depth; ++j) {
         soundspeed[(x_min - j) + (k)*soundspeed_sizex] = left_soundspeed[(left_xmax + 1 - j) + (k)*left_soundspeed_sizex];
@@ -163,7 +170,8 @@ void update_tile_halo_l_kernel(global_variables &globals, int x_min, int x_max, 
     size_t xvel0_sizex = xvel0_buffer.nX();
     double *left_xvel0 = left_xvel0_buffer.data;
     size_t left_xvel0_sizex = left_xvel0_buffer.nX();
-#pragma acc parallel loop gang worker vector default(present) clover_use_target(globals.context.use_target)
+#pragma acc parallel loop gang worker vector clover_use_target(globals.context.use_target) \
+    present(xvel0[ : xvel0_buffer.N()], left_xvel0[ : left_xvel0_buffer.N()])
     for (int k = (y_min - depth + 1); k < (y_max + 1 + depth + 2); k++) {
       for (int j = 0; j < depth; ++j) {
         xvel0[(x_min - j) + (k)*xvel0_sizex] = left_xvel0[(left_xmax + 1 - j) + (k)*left_xvel0_sizex];
@@ -179,7 +187,8 @@ void update_tile_halo_l_kernel(global_variables &globals, int x_min, int x_max, 
     size_t xvel1_sizex = xvel1_buffer.nX();
     double *left_xvel1 = left_xvel1_buffer.data;
     size_t left_xvel1_sizex = left_xvel1_buffer.nX();
-#pragma acc parallel loop gang worker vector default(present) clover_use_target(globals.context.use_target)
+#pragma acc parallel loop gang worker vector clover_use_target(globals.context.use_target) \
+    present(xvel1[ : xvel1_buffer.N()], left_xvel1[ : left_xvel1_buffer.N()])
     for (int k = (y_min - depth + 1); k < (y_max + 1 + depth + 2); k++) {
       for (int j = 0; j < depth; ++j) {
         xvel1[(x_min - j) + (k)*xvel1_sizex] = left_xvel1[(left_xmax + 1 - j) + (k)*left_xvel1_sizex];
@@ -195,7 +204,8 @@ void update_tile_halo_l_kernel(global_variables &globals, int x_min, int x_max, 
     size_t yvel0_sizex = yvel0_buffer.nX();
     double *left_yvel0 = left_yvel0_buffer.data;
     size_t left_yvel0_sizex = left_yvel0_buffer.nX();
-#pragma acc parallel loop gang worker vector default(present) clover_use_target(globals.context.use_target)
+#pragma acc parallel loop gang worker vector clover_use_target(globals.context.use_target) \
+    present(yvel0[ : yvel0_buffer.N()], left_yvel0[ : left_yvel0_buffer.N()])
     for (int k = (y_min - depth + 1); k < (y_max + 1 + depth + 2); k++) {
       for (int j = 0; j < depth; ++j) {
         yvel0[(x_min - j) + (k)*yvel0_sizex] = left_yvel0[(left_xmax + 1 - j) + (k)*left_yvel0_sizex];
@@ -211,7 +221,8 @@ void update_tile_halo_l_kernel(global_variables &globals, int x_min, int x_max, 
     size_t yvel1_sizex = yvel1_buffer.nX();
     double *left_yvel1 = left_yvel1_buffer.data;
     size_t left_yvel1_sizex = left_yvel1_buffer.nX();
-#pragma acc parallel loop gang worker vector default(present) clover_use_target(globals.context.use_target)
+#pragma acc parallel loop gang worker vector clover_use_target(globals.context.use_target) \
+    present(yvel1[ : yvel1_buffer.N()], left_yvel1[ : left_yvel1_buffer.N()])
     for (int k = (y_min - depth + 1); k < (y_max + 1 + depth + 2); k++) {
       for (int j = 0; j < depth; ++j) {
         yvel1[(x_min - j) + (k)*yvel1_sizex] = left_yvel1[(left_xmax + 1 - j) + (k)*left_yvel1_sizex];
@@ -227,7 +238,8 @@ void update_tile_halo_l_kernel(global_variables &globals, int x_min, int x_max, 
     size_t vol_flux_x_sizex = vol_flux_x_buffer.nX();
     double *left_vol_flux_x = left_vol_flux_x_buffer.data;
     size_t left_vol_flux_x_sizex = left_vol_flux_x_buffer.nX();
-#pragma acc parallel loop gang worker vector default(present) clover_use_target(globals.context.use_target)
+#pragma acc parallel loop gang worker vector clover_use_target(globals.context.use_target) \
+    present(vol_flux_x[ : vol_flux_x_buffer.N()], left_vol_flux_x[ : left_vol_flux_x_buffer.N()])
     for (int k = (y_min - depth + 1); k < (y_max + depth + 2); k++) {
       for (int j = 0; j < depth; ++j) {
         vol_flux_x[(x_min - j) + (k)*vol_flux_x_sizex] = left_vol_flux_x[(left_xmax + 1 - j) + (k)*left_vol_flux_x_sizex];
@@ -243,7 +255,8 @@ void update_tile_halo_l_kernel(global_variables &globals, int x_min, int x_max, 
     size_t mass_flux_x_sizex = mass_flux_x_buffer.nX();
     double *left_mass_flux_x = left_mass_flux_x_buffer.data;
     size_t left_mass_flux_x_sizex = left_mass_flux_x_buffer.nX();
-#pragma acc parallel loop gang worker vector default(present) clover_use_target(globals.context.use_target)
+#pragma acc parallel loop gang worker vector clover_use_target(globals.context.use_target) \
+    present(mass_flux_x[ : mass_flux_x_buffer.N()], left_mass_flux_x[ : left_mass_flux_x_buffer.N()])
     for (int k = (y_min - depth + 1); k < (y_max + depth + 2); k++) {
       for (int j = 0; j < depth; ++j) {
         mass_flux_x[(x_min - j) + (k)*mass_flux_x_sizex] = left_mass_flux_x[(left_xmax + 1 - j) + (k)*left_mass_flux_x_sizex];
@@ -259,7 +272,8 @@ void update_tile_halo_l_kernel(global_variables &globals, int x_min, int x_max, 
     size_t vol_flux_y_sizex = vol_flux_y_buffer.nX();
     double *left_vol_flux_y = left_vol_flux_y_buffer.data;
     size_t left_vol_flux_y_sizex = left_vol_flux_y_buffer.nX();
-#pragma acc parallel loop gang worker vector default(present) clover_use_target(globals.context.use_target)
+#pragma acc parallel loop gang worker vector clover_use_target(globals.context.use_target) \
+    present(vol_flux_y[ : vol_flux_y_buffer.N()], left_vol_flux_y[ : left_vol_flux_y_buffer.N()])
     for (int k = (y_min - depth + 1); k < (y_max + 1 + depth + 2); k++) {
       for (int j = 0; j < depth; ++j) {
         vol_flux_y[(x_min - j) + (k)*vol_flux_y_sizex] = left_vol_flux_y[(left_xmax + 1 - j) + (k)*left_vol_flux_y_sizex];
@@ -275,7 +289,8 @@ void update_tile_halo_l_kernel(global_variables &globals, int x_min, int x_max, 
     size_t mass_flux_y_sizex = mass_flux_y_buffer.nX();
     double *left_mass_flux_y = left_mass_flux_y_buffer.data;
     size_t left_mass_flux_y_sizex = left_mass_flux_y_buffer.nX();
-#pragma acc parallel loop gang worker vector default(present) clover_use_target(globals.context.use_target)
+#pragma acc parallel loop gang worker vector clover_use_target(globals.context.use_target) \
+    present(mass_flux_y[ : mass_flux_y_buffer.N()], left_mass_flux_y[ : left_mass_flux_y_buffer.N()])
     for (int k = (y_min - depth + 1); k < (y_max + 1 + depth + 2); k++) {
       for (int j = 0; j < depth; ++j) {
         mass_flux_y[(x_min - j) + (k)*mass_flux_y_sizex] = left_mass_flux_y[(left_xmax + 1 - j) + (k)*left_mass_flux_y_sizex];
@@ -301,6 +316,7 @@ void update_tile_halo_r_kernel(global_variables &globals, int x_min, int x_max, 
                                clover::Buffer2D<double> &right_yvel1_buffer, clover::Buffer2D<double> &right_vol_flux_x_buffer,
                                clover::Buffer2D<double> &right_vol_flux_y_buffer, clover::Buffer2D<double> &right_mass_flux_x_buffer,
                                clover::Buffer2D<double> &right_mass_flux_y_buffer, const int fields[NUM_FIELDS], int depth) {
+{
   // Density 0
   if (fields[field_density0] == 1) {
     // DO k=y_min-depth,y_max+depth
@@ -309,10 +325,11 @@ void update_tile_halo_r_kernel(global_variables &globals, int x_min, int x_max, 
     size_t density0_sizex = density0_buffer.nX();
     double *right_density0 = right_density0_buffer.data;
     size_t right_density0_sizex = right_density0_buffer.nX();
-#pragma acc parallel loop gang worker vector default(present) clover_use_target(globals.context.use_target)
+#pragma acc parallel loop gang worker vector clover_use_target(globals.context.use_target) \
+    present(density0[ : density0_buffer.N()], right_density0[ : right_density0_buffer.N()])
     for (int k = (y_min - depth + 1); k < (y_max + depth + 2); k++) {
       for (int j = 0; j < depth; ++j) {
-        density0[(x_max + 2 + j) + (k)*density0_sizex] = right_density0[(right_xmin - 1 + 2 + j) + (k)*right_density0_sizex];
+        density0[(x_min - j) + (k)*density0_sizex] = right_density0[(right_xmax + 1 - j) + (k)*right_density0_sizex];
       }
     }
   }
@@ -325,10 +342,11 @@ void update_tile_halo_r_kernel(global_variables &globals, int x_min, int x_max, 
     size_t density1_sizex = density1_buffer.nX();
     double *right_density1 = right_density1_buffer.data;
     size_t right_density1_sizex = right_density1_buffer.nX();
-#pragma acc parallel loop gang worker vector default(present) clover_use_target(globals.context.use_target)
+#pragma acc parallel loop gang worker vector clover_use_target(globals.context.use_target) \
+    present(density1[ : density1_buffer.N()], right_density1[ : right_density1_buffer.N()])
     for (int k = (y_min - depth + 1); k < (y_max + depth + 2); k++) {
       for (int j = 0; j < depth; ++j) {
-        density1[(x_max + 2 + j) + (k)*density1_sizex] = right_density1[(right_xmin - 1 + 2 + j) + (k)*right_density1_sizex];
+        density1[(x_min - j) + (k)*density1_sizex] = right_density1[(right_xmax + 1 - j) + (k)*right_density1_sizex];
       }
     }
   }
@@ -341,10 +359,11 @@ void update_tile_halo_r_kernel(global_variables &globals, int x_min, int x_max, 
     size_t energy0_sizex = energy0_buffer.nX();
     double *right_energy0 = right_energy0_buffer.data;
     size_t right_energy0_sizex = right_energy0_buffer.nX();
-#pragma acc parallel loop gang worker vector default(present) clover_use_target(globals.context.use_target)
+#pragma acc parallel loop gang worker vector clover_use_target(globals.context.use_target) \
+    present(energy0[ : energy0_buffer.N()], right_energy0[ : right_energy0_buffer.N()])
     for (int k = (y_min - depth + 1); k < (y_max + depth + 2); k++) {
       for (int j = 0; j < depth; ++j) {
-        energy0[(x_max + 2 + j) + (k)*energy0_sizex] = right_energy0[(right_xmin - 1 + 2 + j) + (k)*right_energy0_sizex];
+        energy0[(x_min - j) + (k)*energy0_sizex] = right_energy0[(right_xmax + 1 - j) + (k)*right_energy0_sizex];
       }
     }
   }
@@ -357,10 +376,11 @@ void update_tile_halo_r_kernel(global_variables &globals, int x_min, int x_max, 
     size_t energy1_sizex = energy1_buffer.nX();
     double *right_energy1 = right_energy1_buffer.data;
     size_t right_energy1_sizex = right_energy1_buffer.nX();
-#pragma acc parallel loop gang worker vector default(present) clover_use_target(globals.context.use_target)
+#pragma acc parallel loop gang worker vector clover_use_target(globals.context.use_target) \
+    present(energy1[ : energy1_buffer.N()], right_energy1[ : right_energy1_buffer.N()])
     for (int k = (y_min - depth + 1); k < (y_max + depth + 2); k++) {
       for (int j = 0; j < depth; ++j) {
-        energy1[(x_max + 2 + j) + (k)*energy1_sizex] = right_energy1[(right_xmin - 1 + 2 + j) + (k)*right_energy1_sizex];
+        energy1[(x_min - j) + (k)*energy1_sizex] = right_energy1[(right_xmax + 1 - j) + (k)*right_energy1_sizex];
       }
     }
   }
@@ -373,10 +393,11 @@ void update_tile_halo_r_kernel(global_variables &globals, int x_min, int x_max, 
     size_t pressure_sizex = pressure_buffer.nX();
     double *right_pressure = right_pressure_buffer.data;
     size_t right_pressure_sizex = right_pressure_buffer.nX();
-#pragma acc parallel loop gang worker vector default(present) clover_use_target(globals.context.use_target)
+#pragma acc parallel loop gang worker vector clover_use_target(globals.context.use_target) \
+    present(pressure[ : pressure_buffer.N()], right_pressure[ : right_pressure_buffer.N()])
     for (int k = (y_min - depth + 1); k < (y_max + depth + 2); k++) {
       for (int j = 0; j < depth; ++j) {
-        pressure[(x_max + 2 + j) + (k)*pressure_sizex] = right_pressure[(right_xmin - 1 + 2 + j) + (k)*right_pressure_sizex];
+        pressure[(x_min - j) + (k)*pressure_sizex] = right_pressure[(right_xmax + 1 - j) + (k)*right_pressure_sizex];
       }
     }
   }
@@ -389,10 +410,11 @@ void update_tile_halo_r_kernel(global_variables &globals, int x_min, int x_max, 
     size_t viscosity_sizex = viscosity_buffer.nX();
     double *right_viscosity = right_viscosity_buffer.data;
     size_t right_viscosity_sizex = right_viscosity_buffer.nX();
-#pragma acc parallel loop gang worker vector default(present) clover_use_target(globals.context.use_target)
+#pragma acc parallel loop gang worker vector clover_use_target(globals.context.use_target) \
+    present(viscosity[ : viscosity_buffer.N()], right_viscosity[ : right_viscosity_buffer.N()])
     for (int k = (y_min - depth + 1); k < (y_max + depth + 2); k++) {
       for (int j = 0; j < depth; ++j) {
-        viscosity[(x_max + 2 + j) + (k)*viscosity_sizex] = right_viscosity[(right_xmin - 1 + 2 + j) + (k)*right_viscosity_sizex];
+        viscosity[(x_min - j) + (k)*viscosity_sizex] = right_viscosity[(right_xmax + 1 - j) + (k)*right_viscosity_sizex];
       }
     }
   }
@@ -405,10 +427,11 @@ void update_tile_halo_r_kernel(global_variables &globals, int x_min, int x_max, 
     size_t soundspeed_sizex = soundspeed_buffer.nX();
     double *right_soundspeed = right_soundspeed_buffer.data;
     size_t right_soundspeed_sizex = right_soundspeed_buffer.nX();
-#pragma acc parallel loop gang worker vector default(present) clover_use_target(globals.context.use_target)
+#pragma acc parallel loop gang worker vector clover_use_target(globals.context.use_target) \
+    present(soundspeed[ : soundspeed_buffer.N()], right_soundspeed[ : right_soundspeed_buffer.N()])
     for (int k = (y_min - depth + 1); k < (y_max + depth + 2); k++) {
       for (int j = 0; j < depth; ++j) {
-        soundspeed[(x_max + 2 + j) + (k)*soundspeed_sizex] = right_soundspeed[(right_xmin - 1 + 2 + j) + (k)*right_soundspeed_sizex];
+        soundspeed[(x_min - j) + (k)*soundspeed_sizex] = right_soundspeed[(right_xmax + 1 - j) + (k)*right_soundspeed_sizex];
       }
     }
   }
@@ -421,10 +444,11 @@ void update_tile_halo_r_kernel(global_variables &globals, int x_min, int x_max, 
     size_t xvel0_sizex = xvel0_buffer.nX();
     double *right_xvel0 = right_xvel0_buffer.data;
     size_t right_xvel0_sizex = right_xvel0_buffer.nX();
-#pragma acc parallel loop gang worker vector default(present) clover_use_target(globals.context.use_target)
+#pragma acc parallel loop gang worker vector clover_use_target(globals.context.use_target) \
+    present(xvel0[ : xvel0_buffer.N()], right_xvel0[ : right_xvel0_buffer.N()])
     for (int k = (y_min - depth + 1); k < (y_max + 1 + depth + 2); k++) {
       for (int j = 0; j < depth; ++j) {
-        xvel0[(x_max + 1 + 2 + j) + (k)*xvel0_sizex] = right_xvel0[(right_xmin + 1 - 1 + 2 + j) + (k)*right_xvel0_sizex];
+        xvel0[(x_min - j) + (k)*xvel0_sizex] = right_xvel0[(right_xmax + 1 - j) + (k)*right_xvel0_sizex];
       }
     }
   }
@@ -437,10 +461,11 @@ void update_tile_halo_r_kernel(global_variables &globals, int x_min, int x_max, 
     size_t xvel1_sizex = xvel1_buffer.nX();
     double *right_xvel1 = right_xvel1_buffer.data;
     size_t right_xvel1_sizex = right_xvel1_buffer.nX();
-#pragma acc parallel loop gang worker vector default(present) clover_use_target(globals.context.use_target)
+#pragma acc parallel loop gang worker vector clover_use_target(globals.context.use_target) \
+    present(xvel1[ : xvel1_buffer.N()], right_xvel1[ : right_xvel1_buffer.N()])
     for (int k = (y_min - depth + 1); k < (y_max + 1 + depth + 2); k++) {
       for (int j = 0; j < depth; ++j) {
-        xvel1[(x_max + 1 + 2 + j) + (k)*xvel1_sizex] = right_xvel1[(right_xmin + 1 - 1 + 2 + j) + (k)*right_xvel1_sizex];
+        xvel1[(x_min - j) + (k)*xvel1_sizex] = right_xvel1[(right_xmax + 1 - j) + (k)*right_xvel1_sizex];
       }
     }
   }
@@ -453,10 +478,11 @@ void update_tile_halo_r_kernel(global_variables &globals, int x_min, int x_max, 
     size_t yvel0_sizex = yvel0_buffer.nX();
     double *right_yvel0 = right_yvel0_buffer.data;
     size_t right_yvel0_sizex = right_yvel0_buffer.nX();
-#pragma acc parallel loop gang worker vector default(present) clover_use_target(globals.context.use_target)
+#pragma acc parallel loop gang worker vector clover_use_target(globals.context.use_target) \
+    present(yvel0[ : yvel0_buffer.N()], right_yvel0[ : right_yvel0_buffer.N()])
     for (int k = (y_min - depth + 1); k < (y_max + 1 + depth + 2); k++) {
       for (int j = 0; j < depth; ++j) {
-        yvel0[(x_max + 1 + 2 + j) + (k)*yvel0_sizex] = right_yvel0[(right_xmin + 1 - 1 + 2 + j) + (k)*right_yvel0_sizex];
+        yvel0[(x_min - j) + (k)*yvel0_sizex] = right_yvel0[(right_xmax + 1 - j) + (k)*right_yvel0_sizex];
       }
     }
   }
@@ -469,10 +495,11 @@ void update_tile_halo_r_kernel(global_variables &globals, int x_min, int x_max, 
     size_t yvel1_sizex = yvel1_buffer.nX();
     double *right_yvel1 = right_yvel1_buffer.data;
     size_t right_yvel1_sizex = right_yvel1_buffer.nX();
-#pragma acc parallel loop gang worker vector default(present) clover_use_target(globals.context.use_target)
+#pragma acc parallel loop gang worker vector clover_use_target(globals.context.use_target) \
+    present(yvel1[ : yvel1_buffer.N()], right_yvel1[ : right_yvel1_buffer.N()])
     for (int k = (y_min - depth + 1); k < (y_max + 1 + depth + 2); k++) {
       for (int j = 0; j < depth; ++j) {
-        yvel1[(x_max + 1 + 2 + j) + (k)*yvel1_sizex] = right_yvel1[(right_xmin + 1 - 1 + 2 + j) + (k)*right_yvel1_sizex];
+        yvel1[(x_min - j) + (k)*yvel1_sizex] = right_yvel1[(right_xmax + 1 - j) + (k)*right_yvel1_sizex];
       }
     }
   }
@@ -485,11 +512,11 @@ void update_tile_halo_r_kernel(global_variables &globals, int x_min, int x_max, 
     size_t vol_flux_x_sizex = vol_flux_x_buffer.nX();
     double *right_vol_flux_x = right_vol_flux_x_buffer.data;
     size_t right_vol_flux_x_sizex = right_vol_flux_x_buffer.nX();
-#pragma acc parallel loop gang worker vector default(present) clover_use_target(globals.context.use_target)
+#pragma acc parallel loop gang worker vector clover_use_target(globals.context.use_target) \
+    present(vol_flux_x[ : vol_flux_x_buffer.N()], right_vol_flux_x[ : right_vol_flux_x_buffer.N()])
     for (int k = (y_min - depth + 1); k < (y_max + depth + 2); k++) {
       for (int j = 0; j < depth; ++j) {
-        vol_flux_x[(x_max + 1 + 2 + j) + (k)*vol_flux_x_sizex] =
-            right_vol_flux_x[(right_xmin + 1 - 1 + 2 + j) + (k)*right_vol_flux_x_sizex];
+        vol_flux_x[(x_min - j) + (k)*vol_flux_x_sizex] = right_vol_flux_x[(right_xmax + 1 - j) + (k)*right_vol_flux_x_sizex];
       }
     }
   }
@@ -502,11 +529,11 @@ void update_tile_halo_r_kernel(global_variables &globals, int x_min, int x_max, 
     size_t mass_flux_x_sizex = mass_flux_x_buffer.nX();
     double *right_mass_flux_x = right_mass_flux_x_buffer.data;
     size_t right_mass_flux_x_sizex = right_mass_flux_x_buffer.nX();
-#pragma acc parallel loop gang worker vector default(present) clover_use_target(globals.context.use_target)
+#pragma acc parallel loop gang worker vector clover_use_target(globals.context.use_target) \
+    present(mass_flux_x[ : mass_flux_x_buffer.N()], right_mass_flux_x[ : right_mass_flux_x_buffer.N()])
     for (int k = (y_min - depth + 1); k < (y_max + depth + 2); k++) {
       for (int j = 0; j < depth; ++j) {
-        mass_flux_x[(x_max + 1 + 2 + j) + (k)*mass_flux_x_sizex] =
-            right_mass_flux_x[(right_xmin + 1 - 1 + 2 + j) + (k)*right_mass_flux_x_sizex];
+        mass_flux_x[(x_min - j) + (k)*mass_flux_x_sizex] = right_mass_flux_x[(right_xmax + 1 - j) + (k)*right_mass_flux_x_sizex];
       }
     }
   }
@@ -519,10 +546,11 @@ void update_tile_halo_r_kernel(global_variables &globals, int x_min, int x_max, 
     size_t vol_flux_y_sizex = vol_flux_y_buffer.nX();
     double *right_vol_flux_y = right_vol_flux_y_buffer.data;
     size_t right_vol_flux_y_sizex = right_vol_flux_y_buffer.nX();
-#pragma acc parallel loop gang worker vector default(present) clover_use_target(globals.context.use_target)
+#pragma acc parallel loop gang worker vector clover_use_target(globals.context.use_target) \
+    present(vol_flux_y[ : vol_flux_y_buffer.N()], right_vol_flux_y[ : right_vol_flux_y_buffer.N()])
     for (int k = (y_min - depth + 1); k < (y_max + 1 + depth + 2); k++) {
       for (int j = 0; j < depth; ++j) {
-        vol_flux_y[(x_max + 2 + j) + (k)*vol_flux_y_sizex] = right_vol_flux_y[(right_xmin - 1 + 2 + j) + (k)*right_vol_flux_y_sizex];
+        vol_flux_y[(x_min - j) + (k)*vol_flux_y_sizex] = right_vol_flux_y[(right_xmax + 1 - j) + (k)*right_vol_flux_y_sizex];
       }
     }
   }
@@ -535,14 +563,15 @@ void update_tile_halo_r_kernel(global_variables &globals, int x_min, int x_max, 
     size_t mass_flux_y_sizex = mass_flux_y_buffer.nX();
     double *right_mass_flux_y = right_mass_flux_y_buffer.data;
     size_t right_mass_flux_y_sizex = right_mass_flux_y_buffer.nX();
-#pragma acc parallel loop gang worker vector default(present) clover_use_target(globals.context.use_target)
+#pragma acc parallel loop gang worker vector clover_use_target(globals.context.use_target) \
+    present(mass_flux_y[ : mass_flux_y_buffer.N()], right_mass_flux_y[ : right_mass_flux_y_buffer.N()])
     for (int k = (y_min - depth + 1); k < (y_max + 1 + depth + 2); k++) {
       for (int j = 0; j < depth; ++j) {
-        mass_flux_y[(x_max + 2 + j) + (k)*mass_flux_y_sizex] = right_mass_flux_y[(right_xmin - 1 + 2 + j) + (k)*right_mass_flux_y_sizex];
+        mass_flux_y[(x_min - j) + (k)*mass_flux_y_sizex] = right_mass_flux_y[(right_xmax + 1 - j) + (k)*right_mass_flux_y_sizex];
       }
     }
   }
-}
+}}
 
 //  Top and bottom only do xmin -> xmax
 //  This is because the corner ghosts will get communicated in the left right
@@ -564,240 +593,255 @@ void update_tile_halo_t_kernel(
     clover::Buffer2D<double> &top_mass_flux_y_buffer, const int fields[NUM_FIELDS], int depth) {
   // Density 0
   if (fields[field_density0] == 1) {
-    for (int k = 0; k < depth; ++k) {
-      // DO j=x_min-depth, x_max+depth
+    // DO k=y_min-depth,y_max+depth
 
-      double *density0 = density0_buffer.data;
-      size_t density0_sizex = density0_buffer.nX();
-      double *top_density0 = top_density0_buffer.data;
-      size_t top_density0_sizex = top_density0_buffer.nX();
-#pragma acc parallel loop gang worker vector default(present) clover_use_target(globals.context.use_target)
-      for (int j = (x_min - depth + 1); j < (x_max + depth + 2); j++) {
-        density0[j + (y_max + 2 + k) * density0_sizex] = top_density0[j + (top_ymin - 1 + 2 + k) * top_density0_sizex];
+    double *density0 = density0_buffer.data;
+    size_t density0_sizex = density0_buffer.nX();
+    double *top_density0 = top_density0_buffer.data;
+    size_t top_density0_sizex = top_density0_buffer.nX();
+#pragma acc parallel loop gang worker vector clover_use_target(globals.context.use_target) \
+    present(density0[ : density0_buffer.N()], top_density0[ : top_density0_buffer.N()])
+    for (int k = (y_min - depth + 1); k < (y_max + depth + 2); k++) {
+      for (int j = 0; j < depth; ++j) {
+        density0[(x_min - j) + (k)*density0_sizex] = top_density0[(top_xmax + 1 - j) + (k)*top_density0_sizex];
       }
     }
   }
 
   // Density 1
   if (fields[field_density1] == 1) {
-    for (int k = 0; k < depth; ++k) {
-      // DO j=x_min-depth, x_max+depth
+    // DO k=y_min-depth,y_max+depth
 
-      double *density1 = density1_buffer.data;
-      size_t density1_sizex = density1_buffer.nX();
-      double *top_density1 = top_density1_buffer.data;
-      size_t top_density1_sizex = top_density1_buffer.nX();
-#pragma acc parallel loop gang worker vector default(present) clover_use_target(globals.context.use_target)
-      for (int j = (x_min - depth + 1); j < (x_max + depth + 2); j++) {
-        density1[j + (y_max + 2 + k) * density1_sizex] = top_density1[j + (top_ymin - 1 + 2 + k) * top_density1_sizex];
+    double *density1 = density1_buffer.data;
+    size_t density1_sizex = density1_buffer.nX();
+    double *top_density1 = top_density1_buffer.data;
+    size_t top_density1_sizex = top_density1_buffer.nX();
+#pragma acc parallel loop gang worker vector clover_use_target(globals.context.use_target) \
+    present(density1[ : density1_buffer.N()], top_density1[ : top_density1_buffer.N()])
+    for (int k = (y_min - depth + 1); k < (y_max + depth + 2); k++) {
+      for (int j = 0; j < depth; ++j) {
+        density1[(x_min - j) + (k)*density1_sizex] = top_density1[(top_xmax + 1 - j) + (k)*top_density1_sizex];
       }
     }
   }
 
   // Energy 0
   if (fields[field_energy0] == 1) {
-    for (int k = 0; k < depth; ++k) {
-      // DO j=x_min-depth, x_max+depth
+    // DO k=y_min-depth,y_max+depth
 
-      double *energy0 = energy0_buffer.data;
-      size_t energy0_sizex = energy0_buffer.nX();
-      double *top_energy0 = top_energy0_buffer.data;
-      size_t top_energy0_sizex = top_energy0_buffer.nX();
-#pragma acc parallel loop gang worker vector default(present) clover_use_target(globals.context.use_target)
-      for (int j = (x_min - depth + 1); j < (x_max + depth + 2); j++) {
-        energy0[j + (y_max + 2 + k) * energy0_sizex] = top_energy0[j + (top_ymin - 1 + 2 + k) * top_energy0_sizex];
+    double *energy0 = energy0_buffer.data;
+    size_t energy0_sizex = energy0_buffer.nX();
+    double *top_energy0 = top_energy0_buffer.data;
+    size_t top_energy0_sizex = top_energy0_buffer.nX();
+#pragma acc parallel loop gang worker vector clover_use_target(globals.context.use_target) \
+    present(energy0[ : energy0_buffer.N()], top_energy0[ : top_energy0_buffer.N()])
+    for (int k = (y_min - depth + 1); k < (y_max + depth + 2); k++) {
+      for (int j = 0; j < depth; ++j) {
+        energy0[(x_min - j) + (k)*energy0_sizex] = top_energy0[(top_xmax + 1 - j) + (k)*top_energy0_sizex];
       }
     }
   }
 
   // Energy 1
   if (fields[field_energy1] == 1) {
-    for (int k = 0; k < depth; ++k) {
-      // DO j=x_min-depth, x_max+depth
+    // DO k=y_min-depth,y_max+depth
 
-      double *energy1 = energy1_buffer.data;
-      size_t energy1_sizex = energy1_buffer.nX();
-      double *top_energy1 = top_energy1_buffer.data;
-      size_t top_energy1_sizex = top_energy1_buffer.nX();
-#pragma acc parallel loop gang worker vector default(present) clover_use_target(globals.context.use_target)
-      for (int j = (x_min - depth + 1); j < (x_max + depth + 2); j++) {
-        energy1[j + (y_max + 2 + k) * energy1_sizex] = top_energy1[j + (top_ymin - 1 + 2 + k) * top_energy1_sizex];
+    double *energy1 = energy1_buffer.data;
+    size_t energy1_sizex = energy1_buffer.nX();
+    double *top_energy1 = top_energy1_buffer.data;
+    size_t top_energy1_sizex = top_energy1_buffer.nX();
+#pragma acc parallel loop gang worker vector clover_use_target(globals.context.use_target) \
+    present(energy1[ : energy1_buffer.N()], top_energy1[ : top_energy1_buffer.N()])
+    for (int k = (y_min - depth + 1); k < (y_max + depth + 2); k++) {
+      for (int j = 0; j < depth; ++j) {
+        energy1[(x_min - j) + (k)*energy1_sizex] = top_energy1[(top_xmax + 1 - j) + (k)*top_energy1_sizex];
       }
     }
   }
 
   // Pressure
   if (fields[field_pressure] == 1) {
-    for (int k = 0; k < depth; ++k) {
-      // DO j=x_min-depth, x_max+depth
+    // DO k=y_min-depth,y_max+depth
 
-      double *pressure = pressure_buffer.data;
-      size_t pressure_sizex = pressure_buffer.nX();
-      double *top_pressure = top_pressure_buffer.data;
-      size_t top_pressure_sizex = top_pressure_buffer.nX();
-#pragma acc parallel loop gang worker vector default(present) clover_use_target(globals.context.use_target)
-      for (int j = (x_min - depth + 1); j < (x_max + depth + 2); j++) {
-        pressure[j + (y_max + 2 + k) * pressure_sizex] = top_pressure[j + (top_ymin - 1 + 2 + k) * top_pressure_sizex];
+    double *pressure = pressure_buffer.data;
+    size_t pressure_sizex = pressure_buffer.nX();
+    double *top_pressure = top_pressure_buffer.data;
+    size_t top_pressure_sizex = top_pressure_buffer.nX();
+#pragma acc parallel loop gang worker vector clover_use_target(globals.context.use_target) \
+    present(pressure[ : pressure_buffer.N()], top_pressure[ : top_pressure_buffer.N()])
+    for (int k = (y_min - depth + 1); k < (y_max + depth + 2); k++) {
+      for (int j = 0; j < depth; ++j) {
+        pressure[(x_min - j) + (k)*pressure_sizex] = top_pressure[(top_xmax + 1 - j) + (k)*top_pressure_sizex];
       }
     }
   }
 
-  // Viscocity
+  // Viscosity
   if (fields[field_viscosity] == 1) {
-    for (int k = 0; k < depth; ++k) {
-      // DO j=x_min-depth, x_max+depth
+    // DO k=y_min-depth,y_max+depth
 
-      double *viscosity = viscosity_buffer.data;
-      size_t viscosity_sizex = viscosity_buffer.nX();
-      double *top_viscosity = top_viscosity_buffer.data;
-      size_t top_viscosity_sizex = top_viscosity_buffer.nX();
-#pragma acc parallel loop gang worker vector default(present) clover_use_target(globals.context.use_target)
-      for (int j = (x_min - depth + 1); j < (x_max + depth + 2); j++) {
-        viscosity[j + (y_max + 2 + k) * viscosity_sizex] = top_viscosity[j + (top_ymin - 1 + 2 + k) * top_viscosity_sizex];
+    double *viscosity = viscosity_buffer.data;
+    size_t viscosity_sizex = viscosity_buffer.nX();
+    double *top_viscosity = top_viscosity_buffer.data;
+    size_t top_viscosity_sizex = top_viscosity_buffer.nX();
+#pragma acc parallel loop gang worker vector clover_use_target(globals.context.use_target) \
+    present(viscosity[ : viscosity_buffer.N()], top_viscosity[ : top_viscosity_buffer.N()])
+    for (int k = (y_min - depth + 1); k < (y_max + depth + 2); k++) {
+      for (int j = 0; j < depth; ++j) {
+        viscosity[(x_min - j) + (k)*viscosity_sizex] = top_viscosity[(top_xmax + 1 - j) + (k)*top_viscosity_sizex];
       }
     }
   }
 
   // Soundspeed
   if (fields[field_soundspeed] == 1) {
-    for (int k = 0; k < depth; ++k) {
-      // DO j=x_min-depth, x_max+depth
+    // DO k=y_min-depth,y_max+depth
 
-      double *soundspeed = soundspeed_buffer.data;
-      size_t soundspeed_sizex = soundspeed_buffer.nX();
-      double *top_soundspeed = top_soundspeed_buffer.data;
-      size_t top_soundspeed_sizex = top_soundspeed_buffer.nX();
-#pragma acc parallel loop gang worker vector default(present) clover_use_target(globals.context.use_target)
-      for (int j = (x_min - depth + 1); j < (x_max + depth + 2); j++) {
-        soundspeed[j + (y_max + 2 + k) * soundspeed_sizex] = top_soundspeed[j + (top_ymin - 1 + 2 + k) * top_soundspeed_sizex];
+    double *soundspeed = soundspeed_buffer.data;
+    size_t soundspeed_sizex = soundspeed_buffer.nX();
+    double *top_soundspeed = top_soundspeed_buffer.data;
+    size_t top_soundspeed_sizex = top_soundspeed_buffer.nX();
+#pragma acc parallel loop gang worker vector clover_use_target(globals.context.use_target) \
+    present(soundspeed[ : soundspeed_buffer.N()], top_soundspeed[ : top_soundspeed_buffer.N()])
+    for (int k = (y_min - depth + 1); k < (y_max + depth + 2); k++) {
+      for (int j = 0; j < depth; ++j) {
+        soundspeed[(x_min - j) + (k)*soundspeed_sizex] = top_soundspeed[(top_xmax + 1 - j) + (k)*top_soundspeed_sizex];
       }
     }
   }
 
   // XVEL 0
   if (fields[field_xvel0] == 1) {
-    for (int k = 0; k < depth; ++k) {
-      // DO j=x_min-depth, x_max+1+depth
+    // DO k=y_min-depth,y_max+1+depth
 
-      double *xvel0 = xvel0_buffer.data;
-      size_t xvel0_sizex = xvel0_buffer.nX();
-      double *top_xvel0 = top_xvel0_buffer.data;
-      size_t top_xvel0_sizex = top_xvel0_buffer.nX();
-#pragma acc parallel loop gang worker vector default(present) clover_use_target(globals.context.use_target)
-      for (int j = (x_min - depth + 1); j < (x_max + 1 + depth + 2); j++) {
-        xvel0[j + (y_max + 1 + 2 + k) * xvel0_sizex] = top_xvel0[j + (top_ymin + 1 - 1 + 2 + k) * top_xvel0_sizex];
+    double *xvel0 = xvel0_buffer.data;
+    size_t xvel0_sizex = xvel0_buffer.nX();
+    double *top_xvel0 = top_xvel0_buffer.data;
+    size_t top_xvel0_sizex = top_xvel0_buffer.nX();
+#pragma acc parallel loop gang worker vector clover_use_target(globals.context.use_target) \
+    present(xvel0[ : xvel0_buffer.N()], top_xvel0[ : top_xvel0_buffer.N()])
+    for (int k = (y_min - depth + 1); k < (y_max + 1 + depth + 2); k++) {
+      for (int j = 0; j < depth; ++j) {
+        xvel0[(x_min - j) + (k)*xvel0_sizex] = top_xvel0[(top_xmax + 1 - j) + (k)*top_xvel0_sizex];
       }
     }
   }
 
   // XVEL 1
   if (fields[field_xvel1] == 1) {
-    for (int k = 0; k < depth; ++k) {
-      // DO j=x_min-depth, x_max+1+depth
+    // DO k=y_min-depth,y_max+1+depth
 
-      double *xvel1 = xvel1_buffer.data;
-      size_t xvel1_sizex = xvel1_buffer.nX();
-      double *top_xvel1 = top_xvel1_buffer.data;
-      size_t top_xvel1_sizex = top_xvel1_buffer.nX();
-#pragma acc parallel loop gang worker vector default(present) clover_use_target(globals.context.use_target)
-      for (int j = (x_min - depth + 1); j < (x_max + 1 + depth + 2); j++) {
-        xvel1[j + (y_max + 1 + 2 + k) * xvel1_sizex] = top_xvel1[j + (top_ymin + 1 - 1 + 2 + k) * top_xvel1_sizex];
+    double *xvel1 = xvel1_buffer.data;
+    size_t xvel1_sizex = xvel1_buffer.nX();
+    double *top_xvel1 = top_xvel1_buffer.data;
+    size_t top_xvel1_sizex = top_xvel1_buffer.nX();
+#pragma acc parallel loop gang worker vector clover_use_target(globals.context.use_target) \
+    present(xvel1[ : xvel1_buffer.N()], top_xvel1[ : top_xvel1_buffer.N()])
+    for (int k = (y_min - depth + 1); k < (y_max + 1 + depth + 2); k++) {
+      for (int j = 0; j < depth; ++j) {
+        xvel1[(x_min - j) + (k)*xvel1_sizex] = top_xvel1[(top_xmax + 1 - j) + (k)*top_xvel1_sizex];
       }
     }
   }
 
   // YVEL 0
   if (fields[field_yvel0] == 1) {
-    for (int k = 0; k < depth; ++k) {
-      // DO j=x_min-depth, x_max+1+depth
+    // DO k=y_min-depth,y_max+1+depth
 
-      double *yvel0 = yvel0_buffer.data;
-      size_t yvel0_sizex = yvel0_buffer.nX();
-      double *top_yvel0 = top_yvel0_buffer.data;
-      size_t top_yvel0_sizex = top_yvel0_buffer.nX();
-#pragma acc parallel loop gang worker vector default(present) clover_use_target(globals.context.use_target)
-      for (int j = (x_min - depth + 1); j < (x_max + 1 + depth + 2); j++) {
-        yvel0[j + (y_max + 1 + 2 + k) * yvel0_sizex] = top_yvel0[j + (top_ymin + 1 - 1 + 2 + k) * top_yvel0_sizex];
+    double *yvel0 = yvel0_buffer.data;
+    size_t yvel0_sizex = yvel0_buffer.nX();
+    double *top_yvel0 = top_yvel0_buffer.data;
+    size_t top_yvel0_sizex = top_yvel0_buffer.nX();
+#pragma acc parallel loop gang worker vector clover_use_target(globals.context.use_target) \
+    present(yvel0[ : yvel0_buffer.N()], top_yvel0[ : top_yvel0_buffer.N()])
+    for (int k = (y_min - depth + 1); k < (y_max + 1 + depth + 2); k++) {
+      for (int j = 0; j < depth; ++j) {
+        yvel0[(x_min - j) + (k)*yvel0_sizex] = top_yvel0[(top_xmax + 1 - j) + (k)*top_yvel0_sizex];
       }
     }
   }
 
   // YVEL 1
   if (fields[field_yvel1] == 1) {
-    for (int k = 0; k < depth; ++k) {
-      // DO j=x_min-depth, x_max+1+depth
+    // DO k=y_min-depth,y_max+1+depth
 
-      double *yvel1 = yvel1_buffer.data;
-      size_t yvel1_sizex = yvel1_buffer.nX();
-      double *top_yvel1 = top_yvel1_buffer.data;
-      size_t top_yvel1_sizex = top_yvel1_buffer.nX();
-#pragma acc parallel loop gang worker vector default(present) clover_use_target(globals.context.use_target)
-      for (int j = (x_min - depth + 1); j < (x_max + 1 + depth + 2); j++) {
-        yvel1[j + (y_max + 1 + 2 + k) * yvel1_sizex] = top_yvel1[j + (top_ymin + 1 - 1 + 2 + k) * top_yvel1_sizex];
+    double *yvel1 = yvel1_buffer.data;
+    size_t yvel1_sizex = yvel1_buffer.nX();
+    double *top_yvel1 = top_yvel1_buffer.data;
+    size_t top_yvel1_sizex = top_yvel1_buffer.nX();
+#pragma acc parallel loop gang worker vector clover_use_target(globals.context.use_target) \
+    present(yvel1[ : yvel1_buffer.N()], top_yvel1[ : top_yvel1_buffer.N()])
+    for (int k = (y_min - depth + 1); k < (y_max + 1 + depth + 2); k++) {
+      for (int j = 0; j < depth; ++j) {
+        yvel1[(x_min - j) + (k)*yvel1_sizex] = top_yvel1[(top_xmax + 1 - j) + (k)*top_yvel1_sizex];
       }
     }
   }
 
   // VOL_FLUX_X
   if (fields[field_vol_flux_x] == 1) {
-    for (int k = 0; k < depth; ++k) {
-      // DO j=x_min-depth, x_max+1+depth
+    // DO k=y_min-depth,y_max+depth
 
-      double *vol_flux_x = vol_flux_x_buffer.data;
-      size_t vol_flux_x_sizex = vol_flux_x_buffer.nX();
-      double *top_vol_flux_x = top_vol_flux_x_buffer.data;
-      size_t top_vol_flux_x_sizex = top_vol_flux_x_buffer.nX();
-#pragma acc parallel loop gang worker vector default(present) clover_use_target(globals.context.use_target)
-      for (int j = (x_min - depth + 1); j < (x_max + 1 + depth + 2); j++) {
-        vol_flux_x[j + (y_max + 2 + k) * vol_flux_x_sizex] = top_vol_flux_x[j + (top_ymin - 1 + 2 + k) * top_vol_flux_x_sizex];
+    double *vol_flux_x = vol_flux_x_buffer.data;
+    size_t vol_flux_x_sizex = vol_flux_x_buffer.nX();
+    double *top_vol_flux_x = top_vol_flux_x_buffer.data;
+    size_t top_vol_flux_x_sizex = top_vol_flux_x_buffer.nX();
+#pragma acc parallel loop gang worker vector clover_use_target(globals.context.use_target) \
+    present(vol_flux_x[ : vol_flux_x_buffer.N()], top_vol_flux_x[ : top_vol_flux_x_buffer.N()])
+    for (int k = (y_min - depth + 1); k < (y_max + depth + 2); k++) {
+      for (int j = 0; j < depth; ++j) {
+        vol_flux_x[(x_min - j) + (k)*vol_flux_x_sizex] = top_vol_flux_x[(top_xmax + 1 - j) + (k)*top_vol_flux_x_sizex];
       }
     }
   }
 
   // MASS_FLUX_X
   if (fields[field_mass_flux_x] == 1) {
-    for (int k = 0; k < depth; ++k) {
-      // DO j=x_min-depth, x_max+1+depth
+    // DO k=y_min-depth,y_max+depth
 
-      double *mass_flux_x = mass_flux_x_buffer.data;
-      size_t mass_flux_x_sizex = mass_flux_x_buffer.nX();
-      double *top_mass_flux_x = top_mass_flux_x_buffer.data;
-      size_t top_mass_flux_x_sizex = top_mass_flux_x_buffer.nX();
-#pragma acc parallel loop gang worker vector default(present) clover_use_target(globals.context.use_target)
-      for (int j = (x_min - depth + 1); j < (x_max + 1 + depth + 2); j++) {
-        mass_flux_x[j + (y_max + 2 + k) * mass_flux_x_sizex] = top_mass_flux_x[j + (top_ymin - 1 + 2 + k) * top_mass_flux_x_sizex];
+    double *mass_flux_x = mass_flux_x_buffer.data;
+    size_t mass_flux_x_sizex = mass_flux_x_buffer.nX();
+    double *top_mass_flux_x = top_mass_flux_x_buffer.data;
+    size_t top_mass_flux_x_sizex = top_mass_flux_x_buffer.nX();
+#pragma acc parallel loop gang worker vector clover_use_target(globals.context.use_target) \
+    present(mass_flux_x[ : mass_flux_x_buffer.N()], top_mass_flux_x[ : top_mass_flux_x_buffer.N()])
+    for (int k = (y_min - depth + 1); k < (y_max + depth + 2); k++) {
+      for (int j = 0; j < depth; ++j) {
+        mass_flux_x[(x_min - j) + (k)*mass_flux_x_sizex] = top_mass_flux_x[(top_xmax + 1 - j) + (k)*top_mass_flux_x_sizex];
       }
     }
   }
 
   // VOL_FLUX_Y
   if (fields[field_vol_flux_y] == 1) {
-    for (int k = 0; k < depth; ++k) {
-      // DO j=x_min-depth, x_max+depth
+    // DO k=y_min-depth,y_max+1+depth
 
-      double *vol_flux_y = vol_flux_y_buffer.data;
-      size_t vol_flux_y_sizex = vol_flux_y_buffer.nX();
-      double *top_vol_flux_y = top_vol_flux_y_buffer.data;
-      size_t top_vol_flux_y_sizex = top_vol_flux_y_buffer.nX();
-#pragma acc parallel loop gang worker vector default(present) clover_use_target(globals.context.use_target)
-      for (int j = (x_min - depth + 1); j < (x_max + depth + 2); j++) {
-        vol_flux_y[j + (y_max + 1 + 2 + k) * vol_flux_y_sizex] = top_vol_flux_y[j + (top_ymin + 1 - 1 + 2 + k) * top_vol_flux_y_sizex];
+    double *vol_flux_y = vol_flux_y_buffer.data;
+    size_t vol_flux_y_sizex = vol_flux_y_buffer.nX();
+    double *top_vol_flux_y = top_vol_flux_y_buffer.data;
+    size_t top_vol_flux_y_sizex = top_vol_flux_y_buffer.nX();
+#pragma acc parallel loop gang worker vector clover_use_target(globals.context.use_target) \
+    present(vol_flux_y[ : vol_flux_y_buffer.N()], top_vol_flux_y[ : top_vol_flux_y_buffer.N()])
+    for (int k = (y_min - depth + 1); k < (y_max + 1 + depth + 2); k++) {
+      for (int j = 0; j < depth; ++j) {
+        vol_flux_y[(x_min - j) + (k)*vol_flux_y_sizex] = top_vol_flux_y[(top_xmax + 1 - j) + (k)*top_vol_flux_y_sizex];
       }
     }
   }
 
   // MASS_FLUX_Y
   if (fields[field_mass_flux_y] == 1) {
-    for (int k = 0; k < depth; ++k) {
-      // DO j=x_min-depth, x_max+depth
+    // DO k=y_min-depth,y_max+1+depth
 
-      double *mass_flux_y = mass_flux_y_buffer.data;
-      size_t mass_flux_y_sizex = mass_flux_y_buffer.nX();
-      double *top_mass_flux_y = top_mass_flux_y_buffer.data;
-      size_t top_mass_flux_y_sizex = top_mass_flux_y_buffer.nX();
-#pragma acc parallel loop gang worker vector default(present) clover_use_target(globals.context.use_target)
-      for (int j = (x_min - depth + 1); j < (x_max + depth + 2); j++) {
-        mass_flux_y[j + (y_max + 1 + 2 + k) * mass_flux_y_sizex] = top_mass_flux_y[j + (top_ymin + 1 - 1 + 2 + k) * top_mass_flux_y_sizex];
+    double *mass_flux_y = mass_flux_y_buffer.data;
+    size_t mass_flux_y_sizex = mass_flux_y_buffer.nX();
+    double *top_mass_flux_y = top_mass_flux_y_buffer.data;
+    size_t top_mass_flux_y_sizex = top_mass_flux_y_buffer.nX();
+#pragma acc parallel loop gang worker vector clover_use_target(globals.context.use_target) \
+    present(mass_flux_y[ : mass_flux_y_buffer.N()], top_mass_flux_y[ : top_mass_flux_y_buffer.N()])
+    for (int k = (y_min - depth + 1); k < (y_max + 1 + depth + 2); k++) {
+      for (int j = 0; j < depth; ++j) {
+        mass_flux_y[(x_min - j) + (k)*mass_flux_y_sizex] = top_mass_flux_y[(top_xmax + 1 - j) + (k)*top_mass_flux_y_sizex];
       }
     }
   }
@@ -820,240 +864,255 @@ void update_tile_halo_b_kernel(
     clover::Buffer2D<double> &bottom_mass_flux_y_buffer, const int fields[NUM_FIELDS], int depth) {
   // Density 0
   if (fields[field_density0] == 1) {
-    for (int k = 0; k < depth; ++k) {
-      //  DO j=x_min-depth, x_max+depth
+    // DO k=y_min-depth,y_max+depth
 
-      double *density0 = density0_buffer.data;
-      size_t density0_sizex = density0_buffer.nX();
-      double *bottom_density0 = bottom_density0_buffer.data;
-      size_t bottom_density0_sizex = bottom_density0_buffer.nX();
-#pragma acc parallel loop gang worker vector default(present) clover_use_target(globals.context.use_target)
-      for (int j = (x_min - depth + 1); j < (x_max + depth + 2); j++) {
-        density0[j + (y_min - k) * density0_sizex] = bottom_density0[j + (bottom_ymax + 1 - k) * bottom_density0_sizex];
+    double *density0 = density0_buffer.data;
+    size_t density0_sizex = density0_buffer.nX();
+    double *bottom_density0 = bottom_density0_buffer.data;
+    size_t bottom_density0_sizex = bottom_density0_buffer.nX();
+#pragma acc parallel loop gang worker vector clover_use_target(globals.context.use_target) \
+    present(density0[ : density0_buffer.N()], bottom_density0[ : bottom_density0_buffer.N()])
+    for (int k = (y_min - depth + 1); k < (y_max + depth + 2); k++) {
+      for (int j = 0; j < depth; ++j) {
+        density0[(x_min - j) + (k)*density0_sizex] = bottom_density0[(bottom_xmax + 1 - j) + (k)*bottom_density0_sizex];
       }
     }
   }
 
   // Density 1
   if (fields[field_density1] == 1) {
-    for (int k = 0; k < depth; ++k) {
-      //  DO j=x_min-depth, x_max+depth
+    // DO k=y_min-depth,y_max+depth
 
-      double *density1 = density1_buffer.data;
-      size_t density1_sizex = density1_buffer.nX();
-      double *bottom_density1 = bottom_density1_buffer.data;
-      size_t bottom_density1_sizex = bottom_density1_buffer.nX();
-#pragma acc parallel loop gang worker vector default(present) clover_use_target(globals.context.use_target)
-      for (int j = (x_min - depth + 1); j < (x_max + depth + 2); j++) {
-        density1[j + (y_min - k) * density1_sizex] = bottom_density1[j + (bottom_ymax + 1 - k) * bottom_density1_sizex];
+    double *density1 = density1_buffer.data;
+    size_t density1_sizex = density1_buffer.nX();
+    double *bottom_density1 = bottom_density1_buffer.data;
+    size_t bottom_density1_sizex = bottom_density1_buffer.nX();
+#pragma acc parallel loop gang worker vector clover_use_target(globals.context.use_target) \
+    present(density1[ : density1_buffer.N()], bottom_density1[ : bottom_density1_buffer.N()])
+    for (int k = (y_min - depth + 1); k < (y_max + depth + 2); k++) {
+      for (int j = 0; j < depth; ++j) {
+        density1[(x_min - j) + (k)*density1_sizex] = bottom_density1[(bottom_xmax + 1 - j) + (k)*bottom_density1_sizex];
       }
     }
   }
 
   // Energy 0
   if (fields[field_energy0] == 1) {
-    for (int k = 0; k < depth; ++k) {
-      //  DO j=x_min-depth, x_max+depth
+    // DO k=y_min-depth,y_max+depth
 
-      double *energy0 = energy0_buffer.data;
-      size_t energy0_sizex = energy0_buffer.nX();
-      double *bottom_energy0 = bottom_energy0_buffer.data;
-      size_t bottom_energy0_sizex = bottom_energy0_buffer.nX();
-#pragma acc parallel loop gang worker vector default(present) clover_use_target(globals.context.use_target)
-      for (int j = (x_min - depth + 1); j < (x_max + depth + 2); j++) {
-        energy0[j + (y_min - k) * energy0_sizex] = bottom_energy0[j + (bottom_ymax + 1 - k) * bottom_energy0_sizex];
+    double *energy0 = energy0_buffer.data;
+    size_t energy0_sizex = energy0_buffer.nX();
+    double *bottom_energy0 = bottom_energy0_buffer.data;
+    size_t bottom_energy0_sizex = bottom_energy0_buffer.nX();
+#pragma acc parallel loop gang worker vector clover_use_target(globals.context.use_target) \
+    present(energy0[ : energy0_buffer.N()], bottom_energy0[ : bottom_energy0_buffer.N()])
+    for (int k = (y_min - depth + 1); k < (y_max + depth + 2); k++) {
+      for (int j = 0; j < depth; ++j) {
+        energy0[(x_min - j) + (k)*energy0_sizex] = bottom_energy0[(bottom_xmax + 1 - j) + (k)*bottom_energy0_sizex];
       }
     }
   }
 
   // Energy 1
   if (fields[field_energy1] == 1) {
-    for (int k = 0; k < depth; ++k) {
-      //  DO j=x_min-depth, x_max+depth
+    // DO k=y_min-depth,y_max+depth
 
-      double *energy1 = energy1_buffer.data;
-      size_t energy1_sizex = energy1_buffer.nX();
-      double *bottom_energy1 = bottom_energy1_buffer.data;
-      size_t bottom_energy1_sizex = bottom_energy1_buffer.nX();
-#pragma acc parallel loop gang worker vector default(present) clover_use_target(globals.context.use_target)
-      for (int j = (x_min - depth + 1); j < (x_max + depth + 2); j++) {
-        energy1[j + (y_min - k) * energy1_sizex] = bottom_energy1[j + (bottom_ymax + 1 - k) * bottom_energy1_sizex];
+    double *energy1 = energy1_buffer.data;
+    size_t energy1_sizex = energy1_buffer.nX();
+    double *bottom_energy1 = bottom_energy1_buffer.data;
+    size_t bottom_energy1_sizex = bottom_energy1_buffer.nX();
+#pragma acc parallel loop gang worker vector clover_use_target(globals.context.use_target) \
+    present(energy1[ : energy1_buffer.N()], bottom_energy1[ : bottom_energy1_buffer.N()])
+    for (int k = (y_min - depth + 1); k < (y_max + depth + 2); k++) {
+      for (int j = 0; j < depth; ++j) {
+        energy1[(x_min - j) + (k)*energy1_sizex] = bottom_energy1[(bottom_xmax + 1 - j) + (k)*bottom_energy1_sizex];
       }
     }
   }
 
   // Pressure
   if (fields[field_pressure] == 1) {
-    for (int k = 0; k < depth; ++k) {
-      //  DO j=x_min-depth, x_max+depth
+    // DO k=y_min-depth,y_max+depth
 
-      double *pressure = pressure_buffer.data;
-      size_t pressure_sizex = pressure_buffer.nX();
-      double *bottom_pressure = bottom_pressure_buffer.data;
-      size_t bottom_pressure_sizex = bottom_pressure_buffer.nX();
-#pragma acc parallel loop gang worker vector default(present) clover_use_target(globals.context.use_target)
-      for (int j = (x_min - depth + 1); j < (x_max + depth + 2); j++) {
-        pressure[j + (y_min - k) * pressure_sizex] = bottom_pressure[j + (bottom_ymax + 1 - k) * bottom_pressure_sizex];
+    double *pressure = pressure_buffer.data;
+    size_t pressure_sizex = pressure_buffer.nX();
+    double *bottom_pressure = bottom_pressure_buffer.data;
+    size_t bottom_pressure_sizex = bottom_pressure_buffer.nX();
+#pragma acc parallel loop gang worker vector clover_use_target(globals.context.use_target) \
+    present(pressure[ : pressure_buffer.N()], bottom_pressure[ : bottom_pressure_buffer.N()])
+    for (int k = (y_min - depth + 1); k < (y_max + depth + 2); k++) {
+      for (int j = 0; j < depth; ++j) {
+        pressure[(x_min - j) + (k)*pressure_sizex] = bottom_pressure[(bottom_xmax + 1 - j) + (k)*bottom_pressure_sizex];
       }
     }
   }
 
-  // Viscocity
+  // Viscosity
   if (fields[field_viscosity] == 1) {
-    for (int k = 0; k < depth; ++k) {
-      //  DO j=x_min-depth, x_max+depth
+    // DO k=y_min-depth,y_max+depth
 
-      double *viscosity = viscosity_buffer.data;
-      size_t viscosity_sizex = viscosity_buffer.nX();
-      double *bottom_viscosity = bottom_viscosity_buffer.data;
-      size_t bottom_viscosity_sizex = bottom_viscosity_buffer.nX();
-#pragma acc parallel loop gang worker vector default(present) clover_use_target(globals.context.use_target)
-      for (int j = (x_min - depth + 1); j < (x_max + depth + 2); j++) {
-        viscosity[j + (y_min - k) * viscosity_sizex] = bottom_viscosity[j + (bottom_ymax + 1 - k) * bottom_viscosity_sizex];
+    double *viscosity = viscosity_buffer.data;
+    size_t viscosity_sizex = viscosity_buffer.nX();
+    double *bottom_viscosity = bottom_viscosity_buffer.data;
+    size_t bottom_viscosity_sizex = bottom_viscosity_buffer.nX();
+#pragma acc parallel loop gang worker vector clover_use_target(globals.context.use_target) \
+    present(viscosity[ : viscosity_buffer.N()], bottom_viscosity[ : bottom_viscosity_buffer.N()])
+    for (int k = (y_min - depth + 1); k < (y_max + depth + 2); k++) {
+      for (int j = 0; j < depth; ++j) {
+        viscosity[(x_min - j) + (k)*viscosity_sizex] = bottom_viscosity[(bottom_xmax + 1 - j) + (k)*bottom_viscosity_sizex];
       }
     }
   }
 
   // Soundspeed
   if (fields[field_soundspeed] == 1) {
-    for (int k = 0; k < depth; ++k) {
-      //  DO j=x_min-depth, x_max+depth
+    // DO k=y_min-depth,y_max+depth
 
-      double *soundspeed = soundspeed_buffer.data;
-      size_t soundspeed_sizex = soundspeed_buffer.nX();
-      double *bottom_soundspeed = bottom_soundspeed_buffer.data;
-      size_t bottom_soundspeed_sizex = bottom_soundspeed_buffer.nX();
-#pragma acc parallel loop gang worker vector default(present) clover_use_target(globals.context.use_target)
-      for (int j = (x_min - depth + 1); j < (x_max + depth + 2); j++) {
-        soundspeed[j + (y_min - k) * soundspeed_sizex] = bottom_soundspeed[j + (bottom_ymax + 1 - k) * bottom_soundspeed_sizex];
+    double *soundspeed = soundspeed_buffer.data;
+    size_t soundspeed_sizex = soundspeed_buffer.nX();
+    double *bottom_soundspeed = bottom_soundspeed_buffer.data;
+    size_t bottom_soundspeed_sizex = bottom_soundspeed_buffer.nX();
+#pragma acc parallel loop gang worker vector clover_use_target(globals.context.use_target) \
+    present(soundspeed[ : soundspeed_buffer.N()], bottom_soundspeed[ : bottom_soundspeed_buffer.N()])
+    for (int k = (y_min - depth + 1); k < (y_max + depth + 2); k++) {
+      for (int j = 0; j < depth; ++j) {
+        soundspeed[(x_min - j) + (k)*soundspeed_sizex] = bottom_soundspeed[(bottom_xmax + 1 - j) + (k)*bottom_soundspeed_sizex];
       }
     }
   }
 
   // XVEL 0
   if (fields[field_xvel0] == 1) {
-    for (int k = 0; k < depth; ++k) {
-      // DO j=x_min-depth, x_max+1+depth
+    // DO k=y_min-depth,y_max+1+depth
 
-      double *xvel0 = xvel0_buffer.data;
-      size_t xvel0_sizex = xvel0_buffer.nX();
-      double *bottom_xvel0 = bottom_xvel0_buffer.data;
-      size_t bottom_xvel0_sizex = bottom_xvel0_buffer.nX();
-#pragma acc parallel loop gang worker vector default(present) clover_use_target(globals.context.use_target)
-      for (int j = (x_min - depth + 1); j < (x_max + 1 + depth + 2); j++) {
-        xvel0[j + (y_min - k) * xvel0_sizex] = bottom_xvel0[j + (bottom_ymax + 1 - k) * bottom_xvel0_sizex];
+    double *xvel0 = xvel0_buffer.data;
+    size_t xvel0_sizex = xvel0_buffer.nX();
+    double *bottom_xvel0 = bottom_xvel0_buffer.data;
+    size_t bottom_xvel0_sizex = bottom_xvel0_buffer.nX();
+#pragma acc parallel loop gang worker vector clover_use_target(globals.context.use_target) \
+    present(xvel0[ : xvel0_buffer.N()], bottom_xvel0[ : bottom_xvel0_buffer.N()])
+    for (int k = (y_min - depth + 1); k < (y_max + 1 + depth + 2); k++) {
+      for (int j = 0; j < depth; ++j) {
+        xvel0[(x_min - j) + (k)*xvel0_sizex] = bottom_xvel0[(bottom_xmax + 1 - j) + (k)*bottom_xvel0_sizex];
       }
     }
   }
 
   // XVEL 1
   if (fields[field_xvel1] == 1) {
-    for (int k = 0; k < depth; ++k) {
-      // DO j=x_min-depth, x_max+1+depth
+    // DO k=y_min-depth,y_max+1+depth
 
-      double *xvel1 = xvel1_buffer.data;
-      size_t xvel1_sizex = xvel1_buffer.nX();
-      double *bottom_xvel1 = bottom_xvel1_buffer.data;
-      size_t bottom_xvel1_sizex = bottom_xvel1_buffer.nX();
-#pragma acc parallel loop gang worker vector default(present) clover_use_target(globals.context.use_target)
-      for (int j = (x_min - depth + 1); j < (x_max + 1 + depth + 2); j++) {
-        xvel1[j + (y_min - k) * xvel1_sizex] = bottom_xvel1[j + (bottom_ymax + 1 - k) * bottom_xvel1_sizex];
+    double *xvel1 = xvel1_buffer.data;
+    size_t xvel1_sizex = xvel1_buffer.nX();
+    double *bottom_xvel1 = bottom_xvel1_buffer.data;
+    size_t bottom_xvel1_sizex = bottom_xvel1_buffer.nX();
+#pragma acc parallel loop gang worker vector clover_use_target(globals.context.use_target) \
+    present(xvel1[ : xvel1_buffer.N()], bottom_xvel1[ : bottom_xvel1_buffer.N()])
+    for (int k = (y_min - depth + 1); k < (y_max + 1 + depth + 2); k++) {
+      for (int j = 0; j < depth; ++j) {
+        xvel1[(x_min - j) + (k)*xvel1_sizex] = bottom_xvel1[(bottom_xmax + 1 - j) + (k)*bottom_xvel1_sizex];
       }
     }
   }
 
   // YVEL 0
   if (fields[field_yvel0] == 1) {
-    for (int k = 0; k < depth; ++k) {
-      // DO j=x_min-depth, x_max+1+depth
+    // DO k=y_min-depth,y_max+1+depth
 
-      double *yvel0 = yvel0_buffer.data;
-      size_t yvel0_sizex = yvel0_buffer.nX();
-      double *bottom_yvel0 = bottom_yvel0_buffer.data;
-      size_t bottom_yvel0_sizex = bottom_yvel0_buffer.nX();
-#pragma acc parallel loop gang worker vector default(present) clover_use_target(globals.context.use_target)
-      for (int j = (x_min - depth + 1); j < (x_max + 1 + depth + 2); j++) {
-        yvel0[j + (y_min - k) * yvel0_sizex] = bottom_yvel0[j + (bottom_ymax + 1 - k) * bottom_yvel0_sizex];
+    double *yvel0 = yvel0_buffer.data;
+    size_t yvel0_sizex = yvel0_buffer.nX();
+    double *bottom_yvel0 = bottom_yvel0_buffer.data;
+    size_t bottom_yvel0_sizex = bottom_yvel0_buffer.nX();
+#pragma acc parallel loop gang worker vector clover_use_target(globals.context.use_target) \
+    present(yvel0[ : yvel0_buffer.N()], bottom_yvel0[ : bottom_yvel0_buffer.N()])
+    for (int k = (y_min - depth + 1); k < (y_max + 1 + depth + 2); k++) {
+      for (int j = 0; j < depth; ++j) {
+        yvel0[(x_min - j) + (k)*yvel0_sizex] = bottom_yvel0[(bottom_xmax + 1 - j) + (k)*bottom_yvel0_sizex];
       }
     }
   }
 
   // YVEL 1
   if (fields[field_yvel1] == 1) {
-    for (int k = 0; k < depth; ++k) {
-      // DO j=x_min-depth, x_max+1+depth
+    // DO k=y_min-depth,y_max+1+depth
 
-      double *yvel1 = yvel1_buffer.data;
-      size_t yvel1_sizex = yvel1_buffer.nX();
-      double *bottom_yvel1 = bottom_yvel1_buffer.data;
-      size_t bottom_yvel1_sizex = bottom_yvel1_buffer.nX();
-#pragma acc parallel loop gang worker vector default(present) clover_use_target(globals.context.use_target)
-      for (int j = (x_min - depth + 1); j < (x_max + 1 + depth + 2); j++) {
-        yvel1[j + (y_min - k) * yvel1_sizex] = bottom_yvel1[j + (bottom_ymax + 1 - k) * bottom_yvel1_sizex];
+    double *yvel1 = yvel1_buffer.data;
+    size_t yvel1_sizex = yvel1_buffer.nX();
+    double *bottom_yvel1 = bottom_yvel1_buffer.data;
+    size_t bottom_yvel1_sizex = bottom_yvel1_buffer.nX();
+#pragma acc parallel loop gang worker vector clover_use_target(globals.context.use_target) \
+    present(yvel1[ : yvel1_buffer.N()], bottom_yvel1[ : bottom_yvel1_buffer.N()])
+    for (int k = (y_min - depth + 1); k < (y_max + 1 + depth + 2); k++) {
+      for (int j = 0; j < depth; ++j) {
+        yvel1[(x_min - j) + (k)*yvel1_sizex] = bottom_yvel1[(bottom_xmax + 1 - j) + (k)*bottom_yvel1_sizex];
       }
     }
   }
 
   // VOL_FLUX_X
   if (fields[field_vol_flux_x] == 1) {
-    for (int k = 0; k < depth; ++k) {
-      // DO j=x_min-depth, x_max+1+depth
+    // DO k=y_min-depth,y_max+depth
 
-      double *vol_flux_x = vol_flux_x_buffer.data;
-      size_t vol_flux_x_sizex = vol_flux_x_buffer.nX();
-      double *bottom_vol_flux_x = bottom_vol_flux_x_buffer.data;
-      size_t bottom_vol_flux_x_sizex = bottom_vol_flux_x_buffer.nX();
-#pragma acc parallel loop gang worker vector default(present) clover_use_target(globals.context.use_target)
-      for (int j = (x_min - depth + 1); j < (x_max + 1 + depth + 2); j++) {
-        vol_flux_x[j + (y_min - k) * vol_flux_x_sizex] = bottom_vol_flux_x[j + (bottom_ymax + 1 - k) * bottom_vol_flux_x_sizex];
+    double *vol_flux_x = vol_flux_x_buffer.data;
+    size_t vol_flux_x_sizex = vol_flux_x_buffer.nX();
+    double *bottom_vol_flux_x = bottom_vol_flux_x_buffer.data;
+    size_t bottom_vol_flux_x_sizex = bottom_vol_flux_x_buffer.nX();
+#pragma acc parallel loop gang worker vector clover_use_target(globals.context.use_target) \
+    present(vol_flux_x[ : vol_flux_x_buffer.N()], bottom_vol_flux_x[ : bottom_vol_flux_x_buffer.N()])
+    for (int k = (y_min - depth + 1); k < (y_max + depth + 2); k++) {
+      for (int j = 0; j < depth; ++j) {
+        vol_flux_x[(x_min - j) + (k)*vol_flux_x_sizex] = bottom_vol_flux_x[(bottom_xmax + 1 - j) + (k)*bottom_vol_flux_x_sizex];
       }
     }
   }
 
   // MASS_FLUX_X
   if (fields[field_mass_flux_x] == 1) {
-    for (int k = 0; k < depth; ++k) {
-      // DO j=x_min-depth, x_max+1+depth
+    // DO k=y_min-depth,y_max+depth
 
-      double *mass_flux_x = mass_flux_x_buffer.data;
-      size_t mass_flux_x_sizex = mass_flux_x_buffer.nX();
-      double *bottom_mass_flux_x = bottom_mass_flux_x_buffer.data;
-      size_t bottom_mass_flux_x_sizex = bottom_mass_flux_x_buffer.nX();
-#pragma acc parallel loop gang worker vector default(present) clover_use_target(globals.context.use_target)
-      for (int j = (x_min - depth + 1); j < (x_max + 1 + depth + 2); j++) {
-        mass_flux_x[j + (y_min - k) * mass_flux_x_sizex] = bottom_mass_flux_x[j + (bottom_ymax + 1 - k) * bottom_mass_flux_x_sizex];
+    double *mass_flux_x = mass_flux_x_buffer.data;
+    size_t mass_flux_x_sizex = mass_flux_x_buffer.nX();
+    double *bottom_mass_flux_x = bottom_mass_flux_x_buffer.data;
+    size_t bottom_mass_flux_x_sizex = bottom_mass_flux_x_buffer.nX();
+#pragma acc parallel loop gang worker vector clover_use_target(globals.context.use_target) \
+    present(mass_flux_x[ : mass_flux_x_buffer.N()], bottom_mass_flux_x[ : bottom_mass_flux_x_buffer.N()])
+    for (int k = (y_min - depth + 1); k < (y_max + depth + 2); k++) {
+      for (int j = 0; j < depth; ++j) {
+        mass_flux_x[(x_min - j) + (k)*mass_flux_x_sizex] = bottom_mass_flux_x[(bottom_xmax + 1 - j) + (k)*bottom_mass_flux_x_sizex];
       }
     }
   }
 
   // VOL_FLUX_Y
   if (fields[field_vol_flux_y] == 1) {
-    for (int k = 0; k < depth; ++k) {
-      // DO j=x_min-depth, x_max+depth
+    // DO k=y_min-depth,y_max+1+depth
 
-      double *vol_flux_y = vol_flux_y_buffer.data;
-      size_t vol_flux_y_sizex = vol_flux_y_buffer.nX();
-      double *bottom_vol_flux_y = bottom_vol_flux_y_buffer.data;
-      size_t bottom_vol_flux_y_sizex = bottom_vol_flux_y_buffer.nX();
-#pragma acc parallel loop gang worker vector default(present) clover_use_target(globals.context.use_target)
-      for (int j = (x_min - depth + 1); j < (x_max + depth + 2); j++) {
-        vol_flux_y[j + (y_min - k) * vol_flux_y_sizex] = bottom_vol_flux_y[j + (bottom_ymax + 1 - k) * bottom_vol_flux_y_sizex];
+    double *vol_flux_y = vol_flux_y_buffer.data;
+    size_t vol_flux_y_sizex = vol_flux_y_buffer.nX();
+    double *bottom_vol_flux_y = bottom_vol_flux_y_buffer.data;
+    size_t bottom_vol_flux_y_sizex = bottom_vol_flux_y_buffer.nX();
+#pragma acc parallel loop gang worker vector clover_use_target(globals.context.use_target) \
+    present(vol_flux_y[ : vol_flux_y_buffer.N()], bottom_vol_flux_y[ : bottom_vol_flux_y_buffer.N()])
+    for (int k = (y_min - depth + 1); k < (y_max + 1 + depth + 2); k++) {
+      for (int j = 0; j < depth; ++j) {
+        vol_flux_y[(x_min - j) + (k)*vol_flux_y_sizex] = bottom_vol_flux_y[(bottom_xmax + 1 - j) + (k)*bottom_vol_flux_y_sizex];
       }
     }
   }
 
   // MASS_FLUX_Y
   if (fields[field_mass_flux_y] == 1) {
-    for (int k = 0; k < depth; ++k) {
-      // DO j=x_min-depth, x_max+depth
+    // DO k=y_min-depth,y_max+1+depth
 
-      double *mass_flux_y = mass_flux_y_buffer.data;
-      size_t mass_flux_y_sizex = mass_flux_y_buffer.nX();
-      double *bottom_mass_flux_y = bottom_mass_flux_y_buffer.data;
-      size_t bottom_mass_flux_y_sizex = bottom_mass_flux_y_buffer.nX();
-#pragma acc parallel loop gang worker vector default(present) clover_use_target(globals.context.use_target)
-      for (int j = (x_min - depth + 1); j < (x_max + depth + 2); j++) {
-        mass_flux_y[j + (y_min - k) * mass_flux_y_sizex] = bottom_mass_flux_y[j + (bottom_ymax + 1 - k) * bottom_mass_flux_y_sizex];
+    double *mass_flux_y = mass_flux_y_buffer.data;
+    size_t mass_flux_y_sizex = mass_flux_y_buffer.nX();
+    double *bottom_mass_flux_y = bottom_mass_flux_y_buffer.data;
+    size_t bottom_mass_flux_y_sizex = bottom_mass_flux_y_buffer.nX();
+#pragma acc parallel loop gang worker vector clover_use_target(globals.context.use_target) \
+    present(mass_flux_y[ : mass_flux_y_buffer.N()], bottom_mass_flux_y[ : bottom_mass_flux_y_buffer.N()])
+    for (int k = (y_min - depth + 1); k < (y_max + 1 + depth + 2); k++) {
+      for (int j = 0; j < depth; ++j) {
+        mass_flux_y[(x_min - j) + (k)*mass_flux_y_sizex] = bottom_mass_flux_y[(bottom_xmax + 1 - j) + (k)*bottom_mass_flux_y_sizex];
       }
     }
   }

--- a/src/acc/viscosity.cpp
+++ b/src/acc/viscosity.cpp
@@ -1,0 +1,106 @@
+/*
+ Crown Copyright 2012 AWE.
+
+ This file is part of CloverLeaf.
+
+ CloverLeaf is free software: you can redistribute it and/or modify it under
+ the terms of the GNU General Public License as published by the
+ Free Software Foundation, either version 3 of the License, or (at your option)
+ any later version.
+
+ CloverLeaf is distributed in the hope that it will be useful, but
+ WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ details.
+
+ You should have received a copy of the GNU General Public License along with
+ CloverLeaf. If not, see http://www.gnu.org/licenses/.
+ */
+
+#include "viscosity.h"
+#include "context.h"
+#include <cmath>
+
+//  @brief Fortran viscosity kernel.
+//  @author Wayne Gaudin
+//  @details Calculates an artificial viscosity using the Wilkin's method to
+//  smooth out shock front and prevent oscillations around discontinuities.
+//  Only cells in compression will have a non-zero value.
+
+void viscosity_kernel(bool use_target, int x_min, int x_max, int y_min, int y_max, field_type &field) {
+
+  // DO k=y_min,y_max
+  //   DO j=x_min,x_max
+
+  const int base_stride = field.base_stride;
+  const int vels_wk_stride = field.vels_wk_stride;
+
+  double *celldx = field.celldx.data;
+  double *celldy = field.celldy.data;
+  double *density0 = field.density0.data;
+  double *pressure = field.pressure.data;
+  double *viscosity = field.viscosity.data;
+  double *xvel0 = field.xvel0.data;
+  double *yvel0 = field.yvel0.data;
+
+#pragma omp target teams distribute parallel for simd collapse(2) clover_use_target(use_target)
+  for (int j = (y_min + 1); j < (y_max + 2); j++) {
+    for (int i = (x_min + 1); i < (x_max + 2); i++) {
+      double ugrad = (xvel0[(i + 1) + (j + 0) * vels_wk_stride] + xvel0[(i + 1) + (j + 1) * vels_wk_stride]) -
+                     (xvel0[i + j * vels_wk_stride] + xvel0[(i + 0) + (j + 1) * vels_wk_stride]);
+      double vgrad = (yvel0[(i + 0) + (j + 1) * vels_wk_stride] + yvel0[(i + 1) + (j + 1) * vels_wk_stride]) -
+                     (yvel0[i + j * vels_wk_stride] + yvel0[(i + 1) + (j + 0) * vels_wk_stride]);
+      double div = (celldx[i] * (ugrad) + celldy[j] * (vgrad));
+      double strain2 = 0.5 *
+                           (xvel0[(i + 0) + (j + 1) * vels_wk_stride] + xvel0[(i + 1) + (j + 1) * vels_wk_stride] -
+                            xvel0[i + j * vels_wk_stride] - xvel0[(i + 1) + (j + 0) * vels_wk_stride]) /
+                           celldy[j] +
+                       0.5 *
+                           (yvel0[(i + 1) + (j + 0) * vels_wk_stride] + yvel0[(i + 1) + (j + 1) * vels_wk_stride] -
+                            yvel0[i + j * vels_wk_stride] - yvel0[(i + 0) + (j + 1) * vels_wk_stride]) /
+                           celldx[i];
+      double pgradx = (pressure[(i + 1) + (j + 0) * base_stride] - pressure[(i - 1) + (j + 0) * base_stride]) / (celldx[i] + celldx[i + 1]);
+      double pgrady = (pressure[(i + 0) + (j + 1) * base_stride] - pressure[(i + 0) + (j - 1) * base_stride]) / (celldy[j] + celldy[j + 2]);
+      double pgradx2 = pgradx * pgradx;
+      double pgrady2 = pgrady * pgrady;
+      double limiter = ((0.5 * (ugrad) / celldx[i]) * pgradx2 + (0.5 * (vgrad) / celldy[j]) * pgrady2 + strain2 * pgradx * pgrady) /
+                       fmax(pgradx2 + pgrady2, g_small);
+      if ((limiter > 0.0) || (div >= 0.0)) {
+        viscosity[i + j * base_stride] = 0.0;
+      } else {
+        double dirx = 1.0;
+        if (pgradx < 0.0) dirx = -1.0;
+        pgradx = dirx * fmax(g_small, fabs(pgradx));
+        double diry = 1.0;
+        if (pgradx < 0.0) diry = -1.0;
+        pgrady = diry * fmax(g_small, fabs(pgrady));
+        double pgrad = sqrt(pgradx * pgradx + pgrady * pgrady);
+        double xgrad = fabs(celldx[i] * pgrad / pgradx);
+        double ygrad = fabs(celldy[j] * pgrad / pgrady);
+        double grad = fmin(xgrad, ygrad);
+        double grad2 = grad * grad;
+        viscosity[i + j * base_stride] = 2.0 * density0[i + j * base_stride] * grad2 * limiter * limiter;
+      }
+    }
+  }
+}
+
+//  @brief Driver for the viscosity kernels
+//  @author Wayne Gaudin
+//  @details Selects the user specified kernel to caluclate the artificial
+//  viscosity.
+void viscosity(global_variables &globals) {
+
+#if SYNC_BUFFERS
+  globals.hostToDevice();
+#endif
+
+  for (int tile = 0; tile < globals.config.tiles_per_chunk; ++tile) {
+    tile_type &t = globals.chunk.tiles[tile];
+    viscosity_kernel(globals.context.use_target, t.info.t_xmin, t.info.t_xmax, t.info.t_ymin, t.info.t_ymax, t.field);
+  }
+
+#if SYNC_BUFFERS
+  globals.deviceToHost();
+#endif
+}

--- a/src/acc/viscosity.cpp
+++ b/src/acc/viscosity.cpp
@@ -43,7 +43,7 @@ void viscosity_kernel(bool use_target, int x_min, int x_max, int y_min, int y_ma
   double *xvel0 = field.xvel0.data;
   double *yvel0 = field.yvel0.data;
 
-#pragma omp target teams distribute parallel for simd collapse(2) clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector default(present) collapse(2) clover_use_target(use_target)
   for (int j = (y_min + 1); j < (y_max + 2); j++) {
     for (int i = (x_min + 1); i < (x_max + 2); i++) {
       double ugrad = (xvel0[(i + 1) + (j + 0) * vels_wk_stride] + xvel0[(i + 1) + (j + 1) * vels_wk_stride]) -

--- a/src/acc/viscosity.cpp
+++ b/src/acc/viscosity.cpp
@@ -43,7 +43,11 @@ void viscosity_kernel(bool use_target, int x_min, int x_max, int y_min, int y_ma
   double *xvel0 = field.xvel0.data;
   double *yvel0 = field.yvel0.data;
 
-#pragma acc parallel loop gang worker vector default(present) collapse(2) clover_use_target(use_target)
+#pragma acc parallel loop gang worker vector collapse(2) clover_use_target(use_target) \
+  present(celldx[ : field.celldx.N()], celldy[ : field.celldy.N()],                    \
+          density0[ : field.density0.N()], pressure[ : field.pressure.N()],            \
+          viscosity[ : field.viscosity.N()], xvel0[ : field.xvel0.N()],                \
+          yvel0[ : field.yvel0.N()])
   for (int j = (y_min + 1); j < (y_max + 2); j++) {
     for (int i = (x_min + 1); i < (x_max + 2); i++) {
       double ugrad = (xvel0[(i + 1) + (j + 0) * vels_wk_stride] + xvel0[(i + 1) + (j + 1) * vels_wk_stride]) -


### PR DESCRIPTION
We have created an OpenACC implementation of Cloverleaf based on the OpenMP Offload Implementation

cc: @jhdavis8

## Implementation Notes

### Pragma Conversions

| OpenMP | OpenACC |
| ------------- | ------------- |
| `omp target`  | `acc`  |
| `teams distribute parallel for simd`  | `parallel loop gang worker vector`  |
| `map(alloc : ...)` | `create(...)`
| `from(...)` | `host(...)` (this gets converted to self)
| `use_device_ptr(...)` | `deviceptr(...)`
| `map(release:...)` | `delete(...)`

For every accelerated loop there is also a `default(present)` clause to indicate that the data is on the GPU and not generate any extra copies.

### Function Conversions
| OpenMP | OpenACC |
| ------------- | ------------- |
| `omp_get_num_devices()`  | `acc_get_num_devices(acc_device_default)`  |
| `omp_set_default_device()` | `acc_set_device_num(..., acc_device_default)` |
| `omp_get_default_device()` | `acc_get_device_num(acc_device_default)` |

Tested with NVHPC@22.7 on V100 and A100 and got similar performance results to the OpenMP version.

Any feedback would be greatly appreciated