### PR TITLE
Revert "Remove AdaptiveCpp workaround in dpl_shim.h to allow for automatic prefetch optimization"

### DIFF
--- a/src/std-indices/dpl_shim.h
+++ b/src/std-indices/dpl_shim.h
@@ -67,7 +67,20 @@ static constexpr auto EXEC_POLICY = std::execution::par_unseq;
 
 #ifdef USE_STD_PTR_ALLOC_DEALLOC
 
+  #if defined(__HIPSYCL__) || defined(__OPENSYCL__)
+    #include <CL/sycl.hpp>
+
+// TODO We temporarily use malloc_shared/free here for hipSYCL stdpar because there's a linking issue if we let it hijack new/delete
+//  for this to work, we compile with --hipsycl-stdpar-system-usm so that hijacking is disabled
+static cl::sycl::queue queue{cl::sycl::default_selector_v};
+template <typename T> T *alloc_raw(size_t size) { return cl::sycl::malloc_shared<T>(size, queue); }
+template <typename T> void dealloc_raw(T *ptr) { cl::sycl::free(ptr, queue); }
+
+  #else
+
 template <typename T> T *alloc_raw(size_t size) { return static_cast<T *>(std::malloc(size * sizeof(T))); }
 template <typename T> void dealloc_raw(T *ptr) { std::free(ptr); }
+
+  #endif
 
 #endif


### PR DESCRIPTION
Reverts UoB-HPC/CloverLeaf#4